### PR TITLE
Add font weight decorators to portable text editor

### DIFF
--- a/src/components/portable-text/article-components.tsx
+++ b/src/components/portable-text/article-components.tsx
@@ -11,35 +11,42 @@ import { cn } from "@/lib/utils";
 export const articleComponents: PortableTextComponents = {
 	block: {
 		normal: ({ children }) => (
-			<p className="text-base leading-relaxed font-light text-muted-foreground">
+			<p className="text-base leading-relaxed font-normal text-muted-foreground">
 				{children}
 			</p>
 		),
+		h1: ({ children }) => (
+			<h1 className="mt-12 text-3xl font-normal text-foreground">{children}</h1>
+		),
 		h2: ({ children }) => (
-			<h2 className="mt-10 text-2xl font-semibold text-foreground">
-				{children}
-			</h2>
+			<h2 className="mt-10 text-2xl font-normal text-foreground">{children}</h2>
 		),
 		h3: ({ children }) => (
-			<h3 className="mt-8 text-xl font-semibold text-foreground">{children}</h3>
+			<h3 className="mt-8 text-xl font-normal text-foreground">{children}</h3>
 		),
 		h4: ({ children }) => (
-			<h4 className="mt-6 text-lg font-semibold text-foreground">{children}</h4>
+			<h4 className="mt-6 text-lg font-normal text-foreground">{children}</h4>
+		),
+		h5: ({ children }) => (
+			<h5 className="mt-6 text-base font-normal text-foreground">{children}</h5>
+		),
+		h6: ({ children }) => (
+			<h6 className="mt-6 text-sm font-normal text-foreground">{children}</h6>
 		),
 		blockquote: ({ children }) => (
-			<blockquote className="my-6 border-l-2 border-border pl-4 text-base font-light text-muted-foreground italic">
+			<blockquote className="my-6 border-l-2 border-border pl-4 text-base font-normal text-muted-foreground italic">
 				{children}
 			</blockquote>
 		),
 	},
 	list: {
 		bullet: ({ children }) => (
-			<ul className="my-3 list-disc space-y-2 pl-6 text-base font-light text-muted-foreground">
+			<ul className="my-3 list-disc space-y-2 pl-6 text-base font-normal text-muted-foreground">
 				{children}
 			</ul>
 		),
 		number: ({ children }) => (
-			<ol className="my-3 list-decimal space-y-2 pl-6 text-base font-light text-muted-foreground">
+			<ol className="my-3 list-decimal space-y-2 pl-6 text-base font-normal text-muted-foreground">
 				{children}
 			</ol>
 		),
@@ -58,6 +65,16 @@ export const articleComponents: PortableTextComponents = {
 				{children}
 			</code>
 		),
+		fontRegular: ({ children }) => (
+			<span className="font-normal">{children}</span>
+		),
+		fontMedium: ({ children }) => (
+			<span className="font-medium">{children}</span>
+		),
+		fontSemibold: ({ children }) => (
+			<span className="font-semibold">{children}</span>
+		),
+		fontBold: ({ children }) => <span className="font-bold">{children}</span>,
 		link: ({ value, children }) => {
 			const href = typeof value?.href === "string" ? value.href : "#";
 			const openInNewTab = Boolean(value?.openInNewTab);

--- a/src/components/portable-text/base-components.tsx
+++ b/src/components/portable-text/base-components.tsx
@@ -7,11 +7,27 @@ import type { PortableTextComponents } from "next-sanity";
  */
 export const baseComponents: PortableTextComponents = {
 	block: {
-		normal: ({ children }) => <p>{children}</p>,
+		normal: ({ children }) => <p className="font-normal">{children}</p>,
+		h1: ({ children }) => <h1 className="font-normal">{children}</h1>,
+		h2: ({ children }) => <h2 className="font-normal">{children}</h2>,
+		h3: ({ children }) => <h3 className="font-normal">{children}</h3>,
+		h4: ({ children }) => <h4 className="font-normal">{children}</h4>,
+		h5: ({ children }) => <h5 className="font-normal">{children}</h5>,
+		h6: ({ children }) => <h6 className="font-normal">{children}</h6>,
 	},
 	marks: {
 		strong: ({ children }) => (
 			<span className="font-medium text-foreground">{children}</span>
 		),
+		fontRegular: ({ children }) => (
+			<span className="font-normal">{children}</span>
+		),
+		fontMedium: ({ children }) => (
+			<span className="font-medium">{children}</span>
+		),
+		fontSemibold: ({ children }) => (
+			<span className="font-semibold">{children}</span>
+		),
+		fontBold: ({ children }) => <span className="font-bold">{children}</span>,
 	},
 };

--- a/src/sanity/schemaTypes/company.ts
+++ b/src/sanity/schemaTypes/company.ts
@@ -1,5 +1,6 @@
 import { CaseIcon } from "@sanity/icons";
-import { defineField, defineType } from "sanity";
+import { defineArrayMember, defineField, defineType } from "sanity";
+import { fontWeightDecorators } from "./portableTextMarks";
 
 export const company = defineType({
 	name: "company",
@@ -50,7 +51,20 @@ export const company = defineType({
 			name: "workDescription",
 			title: "Work Description",
 			type: "array",
-			of: [{ type: "block" }],
+			of: [
+				defineArrayMember({
+					type: "block",
+					marks: {
+						decorators: [
+							{ title: "Strong", value: "strong" },
+							{ title: "Emphasis", value: "em" },
+							{ title: "Underline", value: "underline" },
+							{ title: "Strike", value: "strike-through" },
+							...fontWeightDecorators,
+						],
+					},
+				}),
+			],
 			description:
 				"Description shown on the work page (bold text renders as white highlighted text)",
 		}),

--- a/src/sanity/schemaTypes/portableTextMarks.ts
+++ b/src/sanity/schemaTypes/portableTextMarks.ts
@@ -1,0 +1,19 @@
+export const FONT_WEIGHT_DECORATOR_VALUES = [
+	"fontRegular",
+	"fontMedium",
+	"fontSemibold",
+	"fontBold",
+] as const;
+
+export type FontWeightDecoratorValue =
+	(typeof FONT_WEIGHT_DECORATOR_VALUES)[number];
+
+export const fontWeightDecorators: ReadonlyArray<{
+	title: string;
+	value: FontWeightDecoratorValue;
+}> = [
+	{ title: "Regular", value: "fontRegular" },
+	{ title: "Medium", value: "fontMedium" },
+	{ title: "Semibold", value: "fontSemibold" },
+	{ title: "Bold", value: "fontBold" },
+];

--- a/src/sanity/schemaTypes/siteProfile.ts
+++ b/src/sanity/schemaTypes/siteProfile.ts
@@ -1,5 +1,6 @@
 import { UserIcon } from "@sanity/icons";
 import { defineArrayMember, defineField, defineType } from "sanity";
+import { fontWeightDecorators } from "./portableTextMarks";
 
 export const siteProfile = defineType({
 	name: "siteProfile",
@@ -24,7 +25,20 @@ export const siteProfile = defineType({
 			name: "bio",
 			title: "Biography",
 			type: "array",
-			of: [defineArrayMember({ type: "block" })],
+			of: [
+				defineArrayMember({
+					type: "block",
+					marks: {
+						decorators: [
+							{ title: "Strong", value: "strong" },
+							{ title: "Emphasis", value: "em" },
+							{ title: "Underline", value: "underline" },
+							{ title: "Strike", value: "strike-through" },
+							...fontWeightDecorators,
+						],
+					},
+				}),
+			],
 			description: "Rich text bio - use bold for highlighted text",
 			validation: (rule) => rule.required(),
 		}),

--- a/src/sanity/schemaTypes/workItem.ts
+++ b/src/sanity/schemaTypes/workItem.ts
@@ -1,5 +1,6 @@
 import { ComposeIcon } from "@sanity/icons";
 import { defineArrayMember, defineField, defineType } from "sanity";
+import { fontWeightDecorators } from "./portableTextMarks";
 
 export const workItem = defineType({
 	name: "workItem",
@@ -120,6 +121,7 @@ export const workItem = defineType({
 							{ title: "Strong", value: "strong" },
 							{ title: "Emphasis", value: "em" },
 							{ title: "Code", value: "code" },
+							...fontWeightDecorators,
 						],
 						annotations: [
 							{


### PR DESCRIPTION
Four font weight options (regular, medium, semibold, bold) are now available
in the Sanity rich-text toolbar for bio, company description, and case-study
content. Block renderers default every heading and paragraph to font-normal
so H1-H6 no longer render as bold until a weight decorator is applied.

https://claude.ai/code/session_01B8MaSmgNonLjqjb7MzbJX4