### PR TITLE
feat: progressive blur carousels, fix gradient text clipping and emoj…

### DIFF
--- a/src/app/(site)/(home)/_components/other-works-section/hero-header.tsx
+++ b/src/app/(site)/(home)/_components/other-works-section/hero-header.tsx
@@ -31,11 +31,11 @@ export function HeroHeader({
 					{headingPrefix && (
 						<span className="text-muted-foreground">{headingPrefix} </span>
 					)}
-					<div className="inline-flex items-baseline space-x-2 md:inline">
+					<div className="inline-flex items-baseline md:inline">
 						<GradientText
 							colors={[gradientFrom, gradientTo]}
 							direction="horizontal"
-							className="mx-0 inline-flex! rounded-none font-serif text-4xl"
+							className="mx-0 inline-flex! overflow-visible rounded-none font-serif text-4xl"
 						>
 							{headingHighlight}
 						</GradientText>
@@ -45,11 +45,11 @@ export function HeroHeader({
 								alt=""
 								width={20}
 								height={20}
-								className="inline"
+								className="ml-2 inline"
 								loading="eager"
 							/>
 						) : headingEmoji ? (
-							<span> {headingEmoji}</span>
+							<span className="ml-0.5">{headingEmoji}</span>
 						) : null}
 					</div>
 				</h2>

--- a/src/app/(site)/(home)/_components/other-works-section/other-works-carousel.tsx
+++ b/src/app/(site)/(home)/_components/other-works-section/other-works-carousel.tsx
@@ -8,6 +8,7 @@ import {
 	CarouselContent,
 	CarouselItem,
 } from "@/components/ui/carousel";
+import { ProgressiveBlur } from "@/components/ui/progressive-blur";
 import type { ProjectDTO } from "@/sanity/lib/dal";
 import { ProductCard } from "./product-card";
 
@@ -33,7 +34,7 @@ export function OtherWorksCarousel({ projects }: OtherWorksCarouselProps) {
 	const duplicatedProjects = Array.from({ length: 6 }, () => projects).flat();
 
 	return (
-		<div className="w-full self-center md:[mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
+		<div className="relative -mx-6 w-[calc(100%+3rem)] self-center">
 			<Carousel
 				dir="rtl"
 				opts={{
@@ -64,6 +65,18 @@ export function OtherWorksCarousel({ projects }: OtherWorksCarouselProps) {
 					))}
 				</CarouselContent>
 			</Carousel>
+			<ProgressiveBlur
+				direction="left"
+				blurLayers={8}
+				blurIntensity={0.5}
+				className="absolute inset-y-0 left-0 z-10 hidden w-24 md:block"
+			/>
+			<ProgressiveBlur
+				direction="right"
+				blurLayers={8}
+				blurIntensity={0.5}
+				className="absolute inset-y-0 right-0 z-10 hidden w-24 md:block"
+			/>
 		</div>
 	);
 }

--- a/src/app/(site)/(home)/_components/testimonials-section/testimonials-carousel.tsx
+++ b/src/app/(site)/(home)/_components/testimonials-section/testimonials-carousel.tsx
@@ -8,6 +8,7 @@ import {
 	CarouselContent,
 	CarouselItem,
 } from "@/components/ui/carousel";
+import { ProgressiveBlur } from "@/components/ui/progressive-blur";
 import type { TestimonialDTO } from "@/sanity/lib/dal";
 import { TestimonialCard } from "./testimonial-card";
 
@@ -30,7 +31,7 @@ export function TestimonialsCarousel({
 	);
 
 	return (
-		<div className="w-full self-center md:[mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
+		<div className="-mx-6 w-[calc(100%+3rem)] self-center">
 			<div className="flex w-full flex-col gap-4 md:hidden">
 				{testimonials.map((testimonial, index) => (
 					<div key={`${testimonial.authorName}-${index}`} className="w-full">
@@ -45,7 +46,7 @@ export function TestimonialsCarousel({
 				))}
 			</div>
 
-			<div className="hidden md:block">
+			<div className="relative hidden md:block">
 				<Carousel
 					opts={{
 						align: "start",
@@ -74,6 +75,18 @@ export function TestimonialsCarousel({
 						))}
 					</CarouselContent>
 				</Carousel>
+				<ProgressiveBlur
+					direction="left"
+					blurLayers={8}
+					blurIntensity={0.5}
+					className="absolute inset-y-0 left-0 z-10 w-24"
+				/>
+				<ProgressiveBlur
+					direction="right"
+					blurLayers={8}
+					blurIntensity={0.5}
+					className="absolute inset-y-0 right-0 z-10 w-24"
+				/>
 			</div>
 		</div>
 	);

--- a/src/components/GradientText.tsx
+++ b/src/components/GradientText.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn } from "@/lib/utils";
 import {
 	motion,
 	useAnimationFrame,
@@ -120,7 +121,11 @@ export default function GradientText({
 
 	return (
 		<motion.div
-			className={`relative mx-auto flex max-w-fit flex-row items-center justify-center overflow-hidden rounded-4xl font-medium backdrop-blur transition-shadow duration-500 ${showBorder ? "px-2 py-1" : ""} ${className}`}
+			className={cn(
+				"relative mx-auto flex max-w-fit flex-row items-center justify-center overflow-hidden rounded-4xl font-medium backdrop-blur transition-shadow duration-500",
+				showBorder && "px-2 py-1",
+				className,
+			)}
 			onMouseEnter={handleMouseEnter}
 			onMouseLeave={handleMouseLeave}
 		>
@@ -142,7 +147,7 @@ export default function GradientText({
 				</motion.div>
 			)}
 			<motion.div
-				className="relative z-2 inline-block bg-clip-text text-transparent"
+				className="relative z-2 inline-block bg-clip-text pr-2.5 text-transparent"
 				style={{
 					...gradientStyle,
 					backgroundPosition,

--- a/src/components/ui/progressive-blur.tsx
+++ b/src/components/ui/progressive-blur.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { type HTMLMotionProps, motion } from "motion/react";
+
+export const GRADIENT_ANGLES = {
+	top: 0,
+	right: 90,
+	bottom: 180,
+	left: 270,
+};
+
+export type ProgressiveBlurProps = {
+	direction?: keyof typeof GRADIENT_ANGLES;
+	blurLayers?: number;
+	className?: string;
+	blurIntensity?: number;
+} & HTMLMotionProps<"div">;
+
+export function ProgressiveBlur({
+	direction = "bottom",
+	blurLayers = 8,
+	className,
+	blurIntensity = 0.25,
+	...props
+}: ProgressiveBlurProps) {
+	const layers = Math.max(blurLayers, 2);
+	const segmentSize = 1 / (blurLayers + 1);
+
+	return (
+		<div className={cn("pointer-events-none relative", className)}>
+			{Array.from({ length: layers }).map((_, index) => {
+				const angle = GRADIENT_ANGLES[direction];
+				const gradientStops = [
+					index * segmentSize,
+					(index + 1) * segmentSize,
+					(index + 2) * segmentSize,
+					(index + 3) * segmentSize,
+				].map(
+					(pos, posIndex) =>
+						`rgba(255, 255, 255, ${posIndex === 1 || posIndex === 2 ? 1 : 0}) ${pos * 100}%`,
+				);
+
+				const gradient = `linear-gradient(${angle}deg, ${gradientStops.join(", ")})`;
+
+				return (
+					<motion.div
+						key={index}
+						className="pointer-events-none absolute inset-0 rounded-[inherit]"
+						style={{
+							maskImage: gradient,
+							WebkitMaskImage: gradient,
+							backdropFilter: `blur(${index * blurIntensity}px)`,
+							WebkitBackdropFilter: `blur(${index * blurIntensity}px)`,
+						}}
+						{...props}
+					/>
+				);
+			})}
+		</div>
+	);
+}

--- a/src/sanity/lib/dal.ts
+++ b/src/sanity/lib/dal.ts
@@ -317,8 +317,8 @@ function toWorkPageCompanyDTO(data: WorkPageCompanyRaw): WorkPageCompanyDTO {
 function toSectionHeaderDTO(data: SectionHeaderRaw): SectionHeaderDTO {
 	return {
 		headingPrefix: data.headingPrefix ?? undefined,
-		headingHighlight: data.headingHighlight ?? "",
-		headingEmoji: data.headingEmoji ?? undefined,
+		headingHighlight: data.headingHighlight?.trim() ?? "",
+		headingEmoji: data.headingEmoji?.trim() || undefined,
 		icon: data.icon ? getMediaUrl(data.icon) : undefined,
 		gradientFrom: data.gradientFrom ?? undefined,
 		gradientTo: data.gradientTo ?? undefined,


### PR DESCRIPTION
…i spacing

- Add ProgressiveBlur component (motion-primitives) with backdrop-filter layers
- Replace CSS mask-image on OtherWorks and Testimonials carousels with ProgressiveBlur overlays
- Bleed carousels to container edges (-mx-6, calc(100%+3rem)) for full-width layout
- Fix GradientText to use cn() so overflow-visible properly overrides overflow-hidden
- Add pr-2.5 to inner bg-clip-text div to cover italic font overhang (Caveat)
- Fix hero header emoji spacing: ml-0.5 instead of leading space + space-x-2
- Trim headingHighlight and headingEmoji in DAL transformer to strip Sanity whitespace