### PR TITLE
feat: video hero responsive layout and Cloudinary video integration

### DIFF
--- a/sanity.types.ts
+++ b/sanity.types.ts
@@ -181,9 +181,14 @@ export type Testimonial = {
 			_type: "span";
 			_key: string;
 		}>;
-		style?: "normal";
-		listItem?: never;
-		markDefs?: null;
+		style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+		listItem?: "bullet" | "number" | "check";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
 		level?: number;
 		_type: "block";
 		_key: string;
@@ -213,8 +218,46 @@ export type SiteProfile = {
 	_createdAt: string;
 	_updatedAt: string;
 	_rev: string;
-	name?: string;
-	title?: string;
+	name?: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+		listItem?: "bullet" | "number" | "check";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}>;
+	title?: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+		listItem?: "bullet" | "number" | "check";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}>;
+	availabilityMessage?: string;
+	heroVideo?: CloudinaryAsset;
 	bio?: Array<{
 		children?: Array<{
 			marks?: Array<string>;
@@ -222,9 +265,14 @@ export type SiteProfile = {
 			_type: "span";
 			_key: string;
 		}>;
-		style?: "normal";
-		listItem?: never;
-		markDefs?: null;
+		style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+		listItem?: "bullet" | "number" | "check";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
 		level?: number;
 		_type: "block";
 		_key: string;
@@ -257,7 +305,8 @@ export type Project = {
 	_rev: string;
 	name?: string;
 	image?: CloudinaryAsset;
-	alt?: string;
+	description?: string;
+	url?: string;
 	backgroundColor?: string;
 	order?: number;
 };
@@ -277,10 +326,64 @@ export type Experience = {
 	_createdAt: string;
 	_updatedAt: string;
 	_rev: string;
-	company?: string;
+	company?: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+		listItem?: "bullet" | "number" | "check";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}>;
 	url?: string;
-	role?: string;
-	description?: string;
+	role?: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+		listItem?: "bullet" | "number" | "check";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}>;
+	description?: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+		listItem?: "bullet" | "number" | "check";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}>;
 	order?: number;
 };
 
@@ -303,9 +406,14 @@ export type Company = {
 			_type: "span";
 			_key: string;
 		}>;
-		style?: "normal";
-		listItem?: never;
-		markDefs?: null;
+		style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
+		listItem?: "bullet" | "number" | "check";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
 		level?: number;
 		_type: "block";
 		_key: string;
@@ -483,9 +591,14 @@ export type TestimonialsQueryResult = Array<{
 			_type: "span";
 			_key: string;
 		}>;
-		style?: "normal";
-		listItem?: never;
-		markDefs?: null;
+		style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+		listItem?: "bullet" | "check" | "number";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
 		level?: number;
 		_type: "block";
 		_key: string;
@@ -522,14 +635,14 @@ export type SocialsQueryResult = Array<{
 
 // Source: src/sanity/lib/queries.ts
 // Variable: projectsQuery
-// Query: *[_type == "project"] | order(order asc) {    _id,    name,    image,    alt,    backgroundColor  }
+// Query: *[_type == "project"] | order(order asc) {    _id,    name,    image,    description,    backgroundColor,    url  }
 export type ProjectsQueryResult = Array<{
 	_id: string;
 	name: string | null;
 	image: CloudinaryAsset | null;
 	description: string | null;
 	backgroundColor: string | null;
-	url:string|null
+	url: string | null;
 }>;
 
 // Source: src/sanity/lib/queries.ts
@@ -537,19 +650,109 @@ export type ProjectsQueryResult = Array<{
 // Query: *[_type == "experience"] | order(order asc) {    _id,    company,    url,    role,    description  }
 export type ExperiencesQueryResult = Array<{
 	_id: string;
-	company: string | null;
+	company: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+		listItem?: "bullet" | "check" | "number";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}> | null;
 	url: string | null;
-	role: string | null;
-	description: string | null;
+	role: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+		listItem?: "bullet" | "check" | "number";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}> | null;
+	description: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+		listItem?: "bullet" | "check" | "number";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}> | null;
 }>;
 
 // Source: src/sanity/lib/queries.ts
 // Variable: siteProfileQuery
-// Query: *[_type == "siteProfile"][0] {    _id,    name,    title,    bio  }
+// Query: *[_type == "siteProfile"][0] {    _id,    name,    title,    bio,    availabilityMessage,    heroVideo  }
 export type SiteProfileQueryResult = {
 	_id: string;
-	name: string | null;
-	title: string | null;
+	name: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+		listItem?: "bullet" | "check" | "number";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}> | null;
+	title: Array<{
+		children?: Array<{
+			marks?: Array<string>;
+			text?: string;
+			_type: "span";
+			_key: string;
+		}>;
+		style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+		listItem?: "bullet" | "check" | "number";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
+		level?: number;
+		_type: "block";
+		_key: string;
+	}> | null;
 	bio: Array<{
 		children?: Array<{
 			marks?: Array<string>;
@@ -557,14 +760,20 @@ export type SiteProfileQueryResult = {
 			_type: "span";
 			_key: string;
 		}>;
-		style?: "normal";
-		listItem?: never;
-		markDefs?: null;
+		style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+		listItem?: "bullet" | "check" | "number";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
 		level?: number;
 		_type: "block";
 		_key: string;
 	}> | null;
-	availabilityMessage:string | null
+	availabilityMessage: string | null;
+	heroVideo: CloudinaryAsset | null;
 } | null;
 
 // Source: src/sanity/lib/queries.ts
@@ -594,9 +803,14 @@ export type WorkPageQueryResult = Array<{
 			_type: "span";
 			_key: string;
 		}>;
-		style?: "normal";
-		listItem?: never;
-		markDefs?: null;
+		style?: "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
+		listItem?: "bullet" | "check" | "number";
+		markDefs?: Array<{
+			href?: string;
+			openInNewTab?: boolean;
+			_type: "link";
+			_key: string;
+		}>;
 		level?: number;
 		_type: "block";
 		_key: string;
@@ -726,9 +940,22 @@ export type WorkItemBySlugQueryResult = {
 							_type: "span";
 							_key: string;
 						}>;
-						style?: "normal";
-						listItem?: never;
-						markDefs?: null;
+						style?:
+							| "blockquote"
+							| "h1"
+							| "h2"
+							| "h3"
+							| "h4"
+							| "h5"
+							| "h6"
+							| "normal";
+						listItem?: "bullet" | "check" | "number";
+						markDefs?: Array<{
+							href?: string;
+							openInNewTab?: boolean;
+							_type: "link";
+							_key: string;
+						}>;
 						level?: number;
 						_type: "block";
 						_key: string;
@@ -786,9 +1013,9 @@ declare module "@sanity/client" {
 		'\n  *[_type == "testimonial"] | order(order asc) {\n    _id,\n    quote,\n    authorName,\n    authorRole,\n    authorAvatar,\n    company->{\n      _id,\n      name,\n      logo\n    }\n  }\n': TestimonialsQueryResult;
 		'\n  *[_type == "company"] | order(order asc) {\n    _id,\n    name,\n\t\tlogo,\n\t\twebsite\n\t}\n': CompaniesQueryResult;
 		'\n  *[_type == "social"] | order(order asc) {\n    _id,\n    label,\n    href,\n    icon\n  }\n': SocialsQueryResult;
-		'\n  *[_type == "project"] | order(order asc) {\n    _id,\n    name,\n    image,\n    alt,\n    backgroundColor\n  }\n': ProjectsQueryResult;
+		'\n  *[_type == "project"] | order(order asc) {\n    _id,\n    name,\n    image,\n    description,\n    backgroundColor,\n    url\n  }\n': ProjectsQueryResult;
 		'\n  *[_type == "experience"] | order(order asc) {\n    _id,\n    company,\n    url,\n    role,\n    description\n  }\n': ExperiencesQueryResult;
-		'\n  *[_type == "siteProfile"][0] {\n    _id,\n    name,\n    title,\n    bio\n  }\n': SiteProfileQueryResult;
+		'\n  *[_type == "siteProfile"][0] {\n    _id,\n    name,\n    title,\n    bio,\n    availabilityMessage,\n    heroVideo\n  }\n': SiteProfileQueryResult;
 		'\n  *[_type == "homePage"][0] {\n    sections\n  }\n': HomePageQueryResult;
 		'\n  *[_type == "company" && count(*[_type == "workItem" && references(^._id)]) > 0] | order(order asc) {\n    _id,\n    name,\n    logo,\n    website,\n    isCurrent,\n    badge,\n    workTagline,\n    workDescription,\n    "workItems": *[_type == "workItem" && references(^._id)] | order(order asc) {\n      _id,\n      title,\n      icon,\n      tag,\n      image,\n      description,\n      "slug": slug.current,\n      "brandFrom": brand.primary,\n      "brandTo": brand.secondary\n    }\n  }\n': WorkPageQueryResult;
 		'\n  *[_type == "sectionHeader" && slug.current == $slug][0] {\n    _id,\n    headingPrefix,\n    headingHighlight,\n    headingEmoji,\n    icon,\n    gradientFrom,\n    gradientTo,\n    video,\n    subheading\n  }\n': SectionHeaderQueryResult;

--- a/src/app/(site)/(home)/_components/experience-section/experience-item.tsx
+++ b/src/app/(site)/(home)/_components/experience-section/experience-item.tsx
@@ -9,17 +9,29 @@ import {
 import { ArrowUpRight } from "lucide-react";
 import { PortableText, type PortableTextBlock } from "next-sanity";
 
-const stripBlock = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
+const stripBlock = ({ children }: { children?: React.ReactNode }) => (
+	<>{children}</>
+);
 
 // Heading levels map to sized spans so Sanity heading choices affect font size.
 const sizedBlockComponents = {
 	block: {
 		normal: stripBlock,
-		h1: ({ children }: { children?: React.ReactNode }) => <span className="text-xl leading-snug">{children}</span>,
-		h2: ({ children }: { children?: React.ReactNode }) => <span className="text-lg leading-snug">{children}</span>,
-		h3: ({ children }: { children?: React.ReactNode }) => <span className="text-base leading-snug">{children}</span>,
-		h4: ({ children }: { children?: React.ReactNode }) => <span className="text-sm leading-snug">{children}</span>,
-		h5: ({ children }: { children?: React.ReactNode }) => <span className="text-xs leading-snug">{children}</span>,
+		h1: ({ children }: { children?: React.ReactNode }) => (
+			<span className="text-xl leading-snug">{children}</span>
+		),
+		h2: ({ children }: { children?: React.ReactNode }) => (
+			<span className="text-lg leading-snug">{children}</span>
+		),
+		h3: ({ children }: { children?: React.ReactNode }) => (
+			<span className="text-base leading-snug">{children}</span>
+		),
+		h4: ({ children }: { children?: React.ReactNode }) => (
+			<span className="text-sm leading-snug">{children}</span>
+		),
+		h5: ({ children }: { children?: React.ReactNode }) => (
+			<span className="text-xs leading-snug">{children}</span>
+		),
 		h6: stripBlock,
 		blockquote: stripBlock,
 	},
@@ -42,11 +54,21 @@ const descriptionBlockComponents = {
 };
 
 function SizedPortableText({ value }: { value: PortableTextBlock[] }) {
-	return <PortableText value={value} components={sizedBlockComponents} />;
+	return (
+		<PortableText
+			value={value}
+			components={sizedBlockComponents}
+		/>
+	);
 }
 
 function DescriptionPortableText({ value }: { value: PortableTextBlock[] }) {
-	return <PortableText value={value} components={descriptionBlockComponents} />;
+	return (
+		<PortableText
+			value={value}
+			components={descriptionBlockComponents}
+		/>
+	);
 }
 
 export interface ExperienceItemProps {

--- a/src/app/(site)/(home)/_components/experience-section/experience-item.tsx
+++ b/src/app/(site)/(home)/_components/experience-section/experience-item.tsx
@@ -9,14 +9,25 @@ import {
 import { ArrowUpRight } from "lucide-react";
 import { PortableText, type PortableTextBlock } from "next-sanity";
 
-/**
- * Renders PortableText blocks without a wrapping block element.
- * All block styles (normal, h1–h6, blockquote) collapse to a fragment so the
- * text flows inline inside ItemTitle, ItemDescription, and span contexts —
- * no invalid nested block HTML.
- */
 const stripBlock = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
-const inlineBlockComponents = {
+
+// Heading levels map to sized spans so Sanity heading choices affect font size.
+const sizedBlockComponents = {
+	block: {
+		normal: stripBlock,
+		h1: ({ children }: { children?: React.ReactNode }) => <span className="text-xl leading-snug">{children}</span>,
+		h2: ({ children }: { children?: React.ReactNode }) => <span className="text-lg leading-snug">{children}</span>,
+		h3: ({ children }: { children?: React.ReactNode }) => <span className="text-base leading-snug">{children}</span>,
+		h4: ({ children }: { children?: React.ReactNode }) => <span className="text-sm leading-snug">{children}</span>,
+		h5: ({ children }: { children?: React.ReactNode }) => <span className="text-xs leading-snug">{children}</span>,
+		h6: stripBlock,
+		blockquote: stripBlock,
+	},
+	marks: inlineMarks,
+};
+
+// Description keeps stripBlock — prose where font size changes would be disruptive.
+const descriptionBlockComponents = {
 	block: {
 		normal: stripBlock,
 		h1: stripBlock,
@@ -30,13 +41,12 @@ const inlineBlockComponents = {
 	marks: inlineMarks,
 };
 
-function InlinePortableText({ value }: { value: PortableTextBlock[] }) {
-	return (
-		<PortableText
-			value={value}
-			components={inlineBlockComponents}
-		/>
-	);
+function SizedPortableText({ value }: { value: PortableTextBlock[] }) {
+	return <PortableText value={value} components={sizedBlockComponents} />;
+}
+
+function DescriptionPortableText({ value }: { value: PortableTextBlock[] }) {
+	return <PortableText value={value} components={descriptionBlockComponents} />;
 }
 
 export interface ExperienceItemProps {
@@ -61,16 +71,16 @@ export function ExperienceItem({
 			>
 				<ItemContent>
 					<ItemTitle className="text-base font-semibold text-foreground">
-						<InlinePortableText value={company} />
+						<SizedPortableText value={company} />
 						<ArrowUpRight className="size-4 shrink-0" />
 					</ItemTitle>
 					<ItemDescription className="text-sm font-light">
-						<InlinePortableText value={description} />
+						<DescriptionPortableText value={description} />
 					</ItemDescription>
 				</ItemContent>
 				<ItemActions className="self-start md:self-center">
 					<span className="text-sm font-medium text-muted-foreground">
-						<InlinePortableText value={role} />
+						<SizedPortableText value={role} />
 					</span>
 				</ItemActions>
 			</a>

--- a/src/app/(site)/(home)/_components/intro-section/about-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/about-section.tsx
@@ -46,8 +46,7 @@ export function AboutSection({ bio }: AboutSectionProps) {
 					key={(block as PortableTextBlock & { _key?: string })._key ?? i}
 					initial={{ y: 48, opacity: 0 }}
 					whileInView={{ y: 0, opacity: 1 }}
-					exit={{ y: -24, opacity: 0 }}
-					viewport={{ once: false, margin: "0px 0px -60px 0px" }}
+					viewport={{ once: true, margin: "0px 0px -60px 0px" }}
 					transition={{ ease: "easeOut", duration: 0.6, delay: i * 0.1 }}
 				>
 					<PortableText value={[block]} components={articleComponents} />

--- a/src/app/(site)/(home)/_components/intro-section/about-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/about-section.tsx
@@ -1,5 +1,8 @@
-import type { PortableTextBlock } from "next-sanity";
-import { PortableTextRenderer } from "@/components/portable-text";
+"use client";
+
+import { ARTICLE_PROSE, articleComponents } from "@/components/portable-text";
+import { motion } from "motion/react";
+import { PortableText, type PortableTextBlock } from "next-sanity";
 
 interface AboutSectionProps {
 	bio?: PortableTextBlock[];
@@ -11,7 +14,7 @@ function Highlight({ children }: { children: React.ReactNode }) {
 
 function FallbackBio() {
 	return (
-		<>
+		<div className="space-y-3 text-base font-light text-muted-foreground">
 			<p>
 				Hello, there! My name is <Highlight>Karthik</Highlight>, and I&apos;m a{" "}
 				<Highlight>Product Designer</Highlight> based in Hyderabad. I love
@@ -29,21 +32,27 @@ function FallbackBio() {
 				I&apos;m currently open to new opportunities, so if you think I&apos;d
 				be a great fit, feel free to reach out!
 			</p>
-		</>
+		</div>
 	);
 }
 
 export function AboutSection({ bio }: AboutSectionProps) {
+	if (!bio) return <FallbackBio />;
+
 	return (
-		<div className="space-y-3 text-base font-light text-muted-foreground">
-			{bio ? (
-				<PortableTextRenderer
-					value={bio}
-					variant="article"
-				/>
-			) : (
-				<FallbackBio />
-			)}
+		<div className={ARTICLE_PROSE}>
+			{bio.map((block, i) => (
+				<motion.div
+					key={(block as PortableTextBlock & { _key?: string })._key ?? i}
+					initial={{ y: 48, opacity: 0 }}
+					whileInView={{ y: 0, opacity: 1 }}
+					exit={{ y: -24, opacity: 0 }}
+					viewport={{ once: false, margin: "0px 0px -60px 0px" }}
+					transition={{ ease: "easeOut", duration: 0.6, delay: i * 0.1 }}
+				>
+					<PortableText value={[block]} components={articleComponents} />
+				</motion.div>
+			))}
 		</div>
 	);
 }

--- a/src/app/(site)/(home)/_components/intro-section/about-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/about-section.tsx
@@ -49,7 +49,10 @@ export function AboutSection({ bio }: AboutSectionProps) {
 					viewport={{ once: true, margin: "0px 0px -60px 0px" }}
 					transition={{ ease: "easeOut", duration: 0.6, delay: i * 0.1 }}
 				>
-					<PortableText value={[block]} components={articleComponents} />
+					<PortableText
+						value={[block]}
+						components={articleComponents}
+					/>
 				</motion.div>
 			))}
 		</div>

--- a/src/app/(site)/(home)/_components/intro-section/company-logos-client.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/company-logos-client.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { MediaImage } from "@/components/media";
+import type { CompanyDTO } from "@/sanity/lib/dal";
+import { motion } from "motion/react";
+import * as React from "react";
+
+interface CompanyLogosClientProps {
+	companies: CompanyDTO[];
+}
+
+export function CompanyLogosClient({ companies }: CompanyLogosClientProps) {
+	return (
+		<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
+			{companies.map((company, index) => (
+				<React.Fragment key={company.name}>
+					<motion.div
+						initial={{ opacity: 0, y: 12 }}
+						whileInView={{ opacity: 1, y: 0 }}
+						transition={{ ease: "easeOut", duration: 0.5, delay: index * 0.1 }}
+					>
+						<MediaImage
+							src={company.logo}
+							alt={company.name}
+							width={0}
+							height={0}
+							className="h-7 w-auto object-contain object-left md:h-8"
+							sizes="100vw"
+							loading="eager"
+						/>
+					</motion.div>
+					{index === 1 && (
+						<div className="basis-full min-[425px]:hidden" aria-hidden="true" />
+					)}
+				</React.Fragment>
+			))}
+		</div>
+	);
+}

--- a/src/app/(site)/(home)/_components/intro-section/company-logos-client.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/company-logos-client.tsx
@@ -17,6 +17,7 @@ export function CompanyLogosClient({ companies }: CompanyLogosClientProps) {
 					<motion.div
 						initial={{ opacity: 0, y: 12 }}
 						whileInView={{ opacity: 1, y: 0 }}
+						viewport={{ once: true }}
 						transition={{ ease: "easeOut", duration: 0.5, delay: index * 0.1 }}
 					>
 						<MediaImage

--- a/src/app/(site)/(home)/_components/intro-section/company-logos-client.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/company-logos-client.tsx
@@ -31,7 +31,10 @@ export function CompanyLogosClient({ companies }: CompanyLogosClientProps) {
 						/>
 					</motion.div>
 					{index === 1 && (
-						<div className="basis-full min-[425px]:hidden" aria-hidden="true" />
+						<div
+							className="basis-full min-[425px]:hidden"
+							aria-hidden="true"
+						/>
 					)}
 				</React.Fragment>
 			))}

--- a/src/app/(site)/(home)/_components/intro-section/company-logos-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/company-logos-section.tsx
@@ -1,28 +1,7 @@
-import * as React from "react";
-import { MediaImage } from "@/components/media";
 import { getCompanies } from "@/sanity/lib/dal";
+import { CompanyLogosClient } from "./company-logos-client";
 
 export async function CompanyLogos() {
 	const companies = await getCompanies();
-
-	return (
-		<div className="flex flex-wrap items-center gap-x-4 gap-y-3">
-			{companies.map((company, index) => (
-				<React.Fragment key={company.name}>
-					<MediaImage
-						src={company.logo}
-						alt={company.name}
-						width={0}
-						height={0}
-						className="h-7 w-auto object-contain object-left transition-opacity md:h-8"
-						sizes="100vw"
-						loading="eager"
-					/>
-					{index === 1 && (
-						<div className="basis-full min-[425px]:hidden" aria-hidden="true" />
-					)}
-				</React.Fragment>
-			))}
-		</div>
-	);
+	return <CompanyLogosClient companies={companies} />;
 }

--- a/src/app/(site)/(home)/_components/intro-section/hero-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/hero-section.tsx
@@ -1,30 +1,50 @@
 "use client";
 
-import SplitText from "@/components/SplitText";
+import { inlineMarks } from "@/components/portable-text/inline-marks";
+import { motion } from "motion/react";
+import { PortableText, type PortableTextBlock, type PortableTextComponents } from "next-sanity";
+
+const inlineComponents: PortableTextComponents = {
+	block: {
+		normal: ({ children }) => <>{children}</>,
+		h1: ({ children }) => <>{children}</>,
+		h2: ({ children }) => <>{children}</>,
+		h3: ({ children }) => <>{children}</>,
+		h4: ({ children }) => <>{children}</>,
+		h5: ({ children }) => <>{children}</>,
+		h6: ({ children }) => <>{children}</>,
+	},
+	marks: inlineMarks,
+};
+
+const fadeUp = {
+	initial: { y: 48, opacity: 0 },
+	whileInView: { y: 0, opacity: 1 },
+	viewport: { once: false, margin: "0px 0px -40px 0px" },
+};
 
 interface HeroSectionProps {
-	name: string;
-	title: string;
+	name: PortableTextBlock[];
+	title: PortableTextBlock[];
 }
 
 export function HeroSection({ name, title }: HeroSectionProps) {
 	return (
 		<div className="flex flex-col gap-2">
-			<SplitText
-				text={name}
-				tag="h1"
+			<motion.h1
+				{...fadeUp}
+				transition={{ ease: "easeOut", duration: 0.6 }}
 				className="text-4xl font-semibold text-foreground"
-				splitType="chars"
-				textAlign="left"
-			/>
-			<SplitText
-				text={title}
-				tag="p"
+			>
+				<PortableText value={name} components={inlineComponents} />
+			</motion.h1>
+			<motion.p
+				{...fadeUp}
+				transition={{ ease: "easeOut", duration: 0.6, delay: 0.15 }}
 				className="text-3xl font-semibold text-muted-foreground"
-				splitType="chars"
-				textAlign="left"
-				startDelay={0.4}
-			/>
+			>
+				<PortableText value={title} components={inlineComponents} />
+			</motion.p>
 		</div>
 	);
 }

--- a/src/app/(site)/(home)/_components/intro-section/hero-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/hero-section.tsx
@@ -20,7 +20,7 @@ const inlineComponents: PortableTextComponents = {
 const fadeUp = {
 	initial: { y: 48, opacity: 0 },
 	whileInView: { y: 0, opacity: 1 },
-	viewport: { once: false, margin: "0px 0px -40px 0px" },
+	viewport: { once: true, margin: "0px 0px -40px 0px" },
 };
 
 interface HeroSectionProps {

--- a/src/app/(site)/(home)/_components/intro-section/hero-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/hero-section.tsx
@@ -2,7 +2,11 @@
 
 import { inlineMarks } from "@/components/portable-text/inline-marks";
 import { motion } from "motion/react";
-import { PortableText, type PortableTextBlock, type PortableTextComponents } from "next-sanity";
+import {
+	PortableText,
+	type PortableTextBlock,
+	type PortableTextComponents,
+} from "next-sanity";
 
 const inlineComponents: PortableTextComponents = {
 	block: {
@@ -37,7 +41,10 @@ export function HeroSection({ name, title }: HeroSectionProps) {
 				className="text-4xl font-semibold text-foreground"
 			>
 				{name?.length ? (
-					<PortableText value={name} components={inlineComponents} />
+					<PortableText
+						value={name}
+						components={inlineComponents}
+					/>
 				) : (
 					"Karthik Panchala"
 				)}
@@ -48,7 +55,10 @@ export function HeroSection({ name, title }: HeroSectionProps) {
 				className="text-3xl font-semibold text-muted-foreground"
 			>
 				{title?.length ? (
-					<PortableText value={title} components={inlineComponents} />
+					<PortableText
+						value={title}
+						components={inlineComponents}
+					/>
 				) : (
 					"Product Designer"
 				)}

--- a/src/app/(site)/(home)/_components/intro-section/hero-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/hero-section.tsx
@@ -24,8 +24,8 @@ const fadeUp = {
 };
 
 interface HeroSectionProps {
-	name: PortableTextBlock[];
-	title: PortableTextBlock[];
+	name: PortableTextBlock[] | null;
+	title: PortableTextBlock[] | null;
 }
 
 export function HeroSection({ name, title }: HeroSectionProps) {
@@ -36,14 +36,22 @@ export function HeroSection({ name, title }: HeroSectionProps) {
 				transition={{ ease: "easeOut", duration: 0.6 }}
 				className="text-4xl font-semibold text-foreground"
 			>
-				<PortableText value={name} components={inlineComponents} />
+				{name?.length ? (
+					<PortableText value={name} components={inlineComponents} />
+				) : (
+					"Karthik Panchala"
+				)}
 			</motion.h1>
 			<motion.p
 				{...fadeUp}
 				transition={{ ease: "easeOut", duration: 0.6, delay: 0.15 }}
 				className="text-3xl font-semibold text-muted-foreground"
 			>
-				<PortableText value={title} components={inlineComponents} />
+				{title?.length ? (
+					<PortableText value={title} components={inlineComponents} />
+				) : (
+					"Product Designer"
+				)}
 			</motion.p>
 		</div>
 	);

--- a/src/app/(site)/(home)/_components/intro-section/index.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/index.tsx
@@ -1,5 +1,4 @@
 import { getSiteProfile } from "@/sanity/lib/dal";
-import { toPlainText } from "next-sanity";
 import { AboutSection } from "./about-section";
 import { CompanyLogos } from "./company-logos-section";
 import { HeroSection } from "./hero-section";
@@ -11,8 +10,8 @@ export async function IntroSection() {
 	return (
 		<section className="flex flex-col gap-8">
 			<HeroSection
-				name={profile?.name ? toPlainText(profile.name) : "Karthik Panchala"}
-				title={profile?.title ? toPlainText(profile.title) : "Product Designer"}
+				name={profile?.name ?? []}
+				title={profile?.title ?? []}
 			/>
 			<CompanyLogos />
 			<AboutSection bio={profile?.bio} />

--- a/src/app/(site)/(home)/_components/intro-section/index.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/index.tsx
@@ -10,8 +10,8 @@ export async function IntroSection() {
 	return (
 		<section className="flex flex-col gap-8">
 			<HeroSection
-				name={profile?.name ?? []}
-				title={profile?.title ?? []}
+				name={profile?.name ?? null}
+				title={profile?.title ?? null}
 			/>
 			<CompanyLogos />
 			<AboutSection bio={profile?.bio} />

--- a/src/app/(site)/(home)/_components/other-works-section/other-works-carousel.tsx
+++ b/src/app/(site)/(home)/_components/other-works-section/other-works-carousel.tsx
@@ -74,14 +74,16 @@ export function OtherWorksCarousel({ projects }: OtherWorksCarouselProps) {
 				direction="left"
 				blurLayers={8}
 				blurIntensity={0.5}
-				className="absolute inset-y-0 left-0 z-10 hidden w-24 md:block"
+				className="absolute inset-y-0 left-0 z-10 w-16 md:w-24"
 			/>
+			<div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-background to-transparent" />
 			<ProgressiveBlur
 				direction="right"
 				blurLayers={8}
 				blurIntensity={0.5}
-				className="absolute inset-y-0 right-0 z-10 hidden w-24 md:block"
+				className="absolute inset-y-0 right-0 z-10 w-16 md:w-24"
 			/>
+			<div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-background to-transparent" />
 		</div>
 	);
 }

--- a/src/app/(site)/(home)/_components/other-works-section/other-works-carousel.tsx
+++ b/src/app/(site)/(home)/_components/other-works-section/other-works-carousel.tsx
@@ -74,16 +74,16 @@ export function OtherWorksCarousel({ projects }: OtherWorksCarouselProps) {
 				direction="left"
 				blurLayers={8}
 				blurIntensity={0.5}
-				className="absolute inset-y-0 left-0 z-10 w-16 md:w-24"
+				className="absolute inset-y-0 left-0 z-10 hidden w-24 md:block"
 			/>
-			<div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-background to-transparent" />
+			<div className="pointer-events-none absolute inset-y-0 left-0 z-10 hidden w-8 bg-gradient-to-r from-background to-transparent md:block" />
 			<ProgressiveBlur
 				direction="right"
 				blurLayers={8}
 				blurIntensity={0.5}
-				className="absolute inset-y-0 right-0 z-10 w-16 md:w-24"
+				className="absolute inset-y-0 right-0 z-10 hidden w-24 md:block"
 			/>
-			<div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-background to-transparent" />
+			<div className="pointer-events-none absolute inset-y-0 right-0 z-10 hidden w-8 bg-gradient-to-l from-background to-transparent md:block" />
 		</div>
 	);
 }

--- a/src/app/(site)/(home)/_components/testimonials-section/testimonials-carousel.tsx
+++ b/src/app/(site)/(home)/_components/testimonials-section/testimonials-carousel.tsx
@@ -65,14 +65,16 @@ export function TestimonialsCarousel({
 				direction="left"
 				blurLayers={8}
 				blurIntensity={0.5}
-				className="absolute inset-y-0 left-0 z-10 hidden w-24 md:block"
+				className="absolute inset-y-0 left-0 z-10 w-16 md:w-24"
 			/>
+			<div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-background to-transparent" />
 			<ProgressiveBlur
 				direction="right"
 				blurLayers={8}
 				blurIntensity={0.5}
-				className="absolute inset-y-0 right-0 z-10 hidden w-24 md:block"
+				className="absolute inset-y-0 right-0 z-10 w-16 md:w-24"
 			/>
+			<div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-background to-transparent" />
 		</div>
 	);
 }

--- a/src/app/(site)/(home)/_components/testimonials-section/testimonials-carousel.tsx
+++ b/src/app/(site)/(home)/_components/testimonials-section/testimonials-carousel.tsx
@@ -65,16 +65,16 @@ export function TestimonialsCarousel({
 				direction="left"
 				blurLayers={8}
 				blurIntensity={0.5}
-				className="absolute inset-y-0 left-0 z-10 w-16 md:w-24"
+				className="absolute inset-y-0 left-0 z-10 hidden w-24 md:block"
 			/>
-			<div className="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-background to-transparent" />
+			<div className="pointer-events-none absolute inset-y-0 left-0 z-10 hidden w-8 bg-gradient-to-r from-background to-transparent md:block" />
 			<ProgressiveBlur
 				direction="right"
 				blurLayers={8}
 				blurIntensity={0.5}
-				className="absolute inset-y-0 right-0 z-10 w-16 md:w-24"
+				className="absolute inset-y-0 right-0 z-10 hidden w-24 md:block"
 			/>
-			<div className="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-background to-transparent" />
+			<div className="pointer-events-none absolute inset-y-0 right-0 z-10 hidden w-8 bg-gradient-to-l from-background to-transparent md:block" />
 		</div>
 	);
 }

--- a/src/app/(site)/(home)/_components/video-hero-section/index.tsx
+++ b/src/app/(site)/(home)/_components/video-hero-section/index.tsx
@@ -6,6 +6,8 @@ export async function VideoHeroSection() {
 	return (
 		<VideoHeroSectionClient
 			availabilityMessage={profile?.availabilityMessage ?? ""}
+			heroVideoUrl={profile?.heroVideoUrl ?? ""}
+			heroPosterUrl={profile?.heroPosterUrl ?? ""}
 		/>
 	);
 }

--- a/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
+++ b/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
@@ -4,6 +4,28 @@ import { Pause, Play } from "lucide-react";
 import Image from "next/image";
 import { useRef, useState } from "react";
 
+// ml + w match the "Main circle area" div at every breakpoint so that
+// text-center lands under the circle, not the inner div's midpoint.
+function Caption({ message }: { message: string }) {
+	const splitWord = " but ";
+	const idx = message.toLowerCase().indexOf(splitWord);
+	const content =
+		idx === -1 ? (
+			`(${message})`
+		) : (
+			<>
+				({message.slice(0, idx + 4)}
+				<br className="hidden min-[375px]:block" />
+				{message.slice(idx + 4)})
+			</>
+		);
+	return (
+		<p className="ml-10 min-[375px]:ml-16 md:ml-0 mt-4 w-[13.125rem] min-[375px]:w-[15.9375rem] min-[425px]:w-[17.8125rem] sm:w-[16.875rem] md:w-[22.5rem] text-center font-serif text-[1.125rem] leading-[1.1875rem] font-bold text-[#cccccc] md:text-xl">
+			{content}
+		</p>
+	);
+}
+
 export function VideoHeroSectionClient({
 	availabilityMessage,
 	heroVideoUrl,
@@ -31,28 +53,6 @@ export function VideoHeroSectionClient({
 		if (!videoRef.current) return;
 		videoRef.current.load();
 		setIsPlaying(false);
-	}
-
-	function Caption() {
-		const splitWord = " but ";
-		const idx = availabilityMessage.toLowerCase().indexOf(splitWord);
-		const content =
-			idx === -1 ? (
-				`(${availabilityMessage})`
-			) : (
-				<>
-					({availabilityMessage.slice(0, idx + 4)}
-					<br className="hidden min-[375px]:block" />
-					{availabilityMessage.slice(idx + 4)})
-				</>
-			);
-		// ml + w match the "Main circle area" div at every breakpoint so that
-		// text-center lands under the circle, not the inner div's midpoint.
-		return (
-			<p className="ml-10 min-[375px]:ml-16 md:ml-0 mt-4 w-[13.125rem] min-[375px]:w-[15.9375rem] min-[425px]:w-[17.8125rem] sm:w-[16.875rem] md:w-[22.5rem] text-center font-serif text-[1.125rem] leading-[1.1875rem] font-bold text-[#cccccc] md:text-xl">
-				{content}
-			</p>
-		);
 	}
 
 	return (
@@ -102,11 +102,7 @@ export function VideoHeroSectionClient({
 									className="absolute inset-0 size-full object-cover"
 									onEnded={handleEnded}
 								>
-									{heroVideoUrl ? (
-										<source src={heroVideoUrl} type="video/mp4" />
-									) : (
-										<source src="/Intro.mov" type="video/mp4" />
-									)}
+									<source src={heroVideoUrl || "/Intro.mov"} type="video/mp4" />
 								</video>
 							</div>
 						</div>
@@ -138,7 +134,7 @@ export function VideoHeroSectionClient({
 					</div>
 				</div>
 
-				<Caption />
+				<Caption message={availabilityMessage} />
 			</div>
 		</section>
 	);

--- a/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
+++ b/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
@@ -20,7 +20,7 @@ function Caption({ message }: { message: string }) {
 			</>
 		);
 	return (
-		<p className="ml-10 min-[375px]:ml-16 md:ml-0 mt-4 w-[13.125rem] min-[375px]:w-[15.9375rem] min-[425px]:w-[17.8125rem] sm:w-[16.875rem] md:w-[22.5rem] text-center font-serif text-[1.125rem] leading-[1.1875rem] font-bold text-[#cccccc] md:text-xl">
+		<p className="ml-10 min-[375px]:ml-16 md:ml-0 mt-4 w-[13.125rem] min-[375px]:w-[15.9375rem] min-[425px]:w-[17.8125rem] sm:w-[16.875rem] md:w-[22.5rem] text-center font-serif text-[1.125rem] leading-[1.1875rem] font-bold text-muted-foreground md:text-xl">
 			{content}
 		</p>
 	);
@@ -70,7 +70,7 @@ export function VideoHeroSectionClient({
 					 *   768px+     circle 22.5rem  + ml-0           = 22.5rem  →  text -left-[6.875rem]
 					 *   (1280px+   switches to 2-col grid via site-page.tsx)
 					 */}
-					<p className="absolute top-32 -left-6 -rotate-16 font-serif text-xl leading-tight font-semibold text-[#cccccc] min-[375px]:top-[10.375rem] min-[375px]:-left-[0.875rem] min-[375px]:-rotate-[22deg] min-[375px]:text-2xl sm:top-52 sm:-left-12 sm:text-2xl md:top-[16.25rem] md:-left-[6.875rem] md:text-3xl">
+					<p className="absolute top-32 -left-6 -rotate-16 font-serif text-xl leading-tight font-semibold text-muted-foreground min-[375px]:top-[10.375rem] min-[375px]:-left-[0.875rem] min-[375px]:-rotate-[22deg] min-[375px]:text-2xl sm:top-52 sm:-left-12 sm:text-2xl md:top-[16.25rem] md:-left-[6.875rem] md:text-3xl">
 						Let me
 						<br />
 						introduce

--- a/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
+++ b/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
@@ -20,7 +20,7 @@ function Caption({ message }: { message: string }) {
 			</>
 		);
 	return (
-		<p className="ml-10 min-[375px]:ml-16 md:ml-0 mt-4 w-[13.125rem] min-[375px]:w-[15.9375rem] min-[425px]:w-[17.8125rem] sm:w-[16.875rem] md:w-[22.5rem] text-center font-serif text-[1.125rem] leading-[1.1875rem] font-bold text-muted-foreground md:text-xl">
+		<p className="mt-4 ml-10 w-[13.125rem] text-center font-serif text-[1.125rem] leading-[1.1875rem] font-bold text-muted-foreground min-[375px]:ml-16 min-[375px]:w-[15.9375rem] min-[425px]:w-[17.8125rem] sm:w-[16.875rem] md:ml-0 md:w-[22.5rem] md:text-xl">
 			{content}
 		</p>
 	);
@@ -56,7 +56,7 @@ export function VideoHeroSectionClient({
 	}
 
 	return (
-		<section className="flex flex-col items-end md:items-center xl:items-end -mx-2 md:mx-0">
+		<section className="-mx-2 flex flex-col items-end md:mx-0 md:items-center xl:items-end">
 			<div className="flex flex-col items-center md:translate-x-[7.8125rem] xl:translate-x-0">
 				<div className="relative">
 					{/*
@@ -102,7 +102,10 @@ export function VideoHeroSectionClient({
 									className="absolute inset-0 size-full object-cover"
 									onEnded={handleEnded}
 								>
-									<source src={heroVideoUrl || "/Intro.mov"} type="video/mp4" />
+									<source
+										src={heroVideoUrl || "/Intro.mov"}
+										type="video/mp4"
+									/>
 								</video>
 							</div>
 						</div>
@@ -130,7 +133,6 @@ export function VideoHeroSectionClient({
 								<Play className="size-8 fill-white text-white" />
 							)}
 						</button>
-
 					</div>
 				</div>
 

--- a/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
+++ b/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
@@ -6,8 +6,12 @@ import { useRef, useState } from "react";
 
 export function VideoHeroSectionClient({
 	availabilityMessage,
+	heroVideoUrl,
+	heroPosterUrl,
 }: {
 	availabilityMessage: string;
+	heroVideoUrl: string;
+	heroPosterUrl: string;
 }) {
 	const videoRef = useRef<HTMLVideoElement>(null);
 	const [isPlaying, setIsPlaying] = useState(false);
@@ -23,9 +27,13 @@ export function VideoHeroSectionClient({
 		setIsPlaying(!isPlaying);
 	}
 
-	// Caption rendered in two places: mobile (section-level, self-centered) and
-	// md+ (inside inner div, original flow). CSS show/hide keeps only one visible.
-	function Caption({ className }: { className?: string }) {
+	function handleEnded() {
+		if (!videoRef.current) return;
+		videoRef.current.load();
+		setIsPlaying(false);
+	}
+
+	function Caption() {
 		const splitWord = " but ";
 		const idx = availabilityMessage.toLowerCase().indexOf(splitWord);
 		const content =
@@ -34,34 +42,35 @@ export function VideoHeroSectionClient({
 			) : (
 				<>
 					({availabilityMessage.slice(0, idx + 4)}
-					<br />
-					{availabilityMessage.slice(idx + 5)})
+					<br className="hidden min-[375px]:block" />
+					{availabilityMessage.slice(idx + 4)})
 				</>
 			);
+		// ml + w match the "Main circle area" div at every breakpoint so that
+		// text-center lands under the circle, not the inner div's midpoint.
 		return (
-			<p
-				className={`mt-4 text-center font-serif text-base font-semibold text-[#cccccc] md:text-xl${className ? ` ${className}` : ""}`}
-			>
+			<p className="ml-10 min-[375px]:ml-16 md:ml-0 mt-4 w-[13.125rem] min-[375px]:w-[15.9375rem] min-[425px]:w-[17.8125rem] sm:w-[16.875rem] md:w-[22.5rem] text-center font-serif text-[1.125rem] leading-[1.1875rem] font-bold text-[#cccccc] md:text-xl">
 				{content}
 			</p>
 		);
 	}
 
 	return (
-		<section className="flex flex-col items-end md:items-center xl:items-end">
+		<section className="flex flex-col items-end md:items-center xl:items-end -mx-2 md:mx-0">
 			<div className="flex flex-col items-center md:translate-x-[7.8125rem] xl:translate-x-0">
 				<div className="relative">
 					{/*
 					 * "Let me introduce myself" — rotated, left of the circle
 					 *
 					 * Responsive tiers:
-					 *   < 375px    circle 12.5rem  + ml-10(2.5rem)  = 15rem    →  text -left-6
-					 *   375–639px  circle 13.75rem + ml-16(4rem)    = 17.75rem →  text -left-8
-					 *   640–767px  circle 16.875rem + ml-16(4rem)   = 20.875rem→  text -left-12
+					 *   < 375px    circle 11.25rem  + ml-10(2.5rem)  = 13.75rem  →  text -left-6
+					 *   375–424px  circle 13.125rem + ml-16(4rem)    = 17.125rem →  text -left-8
+					 *   425–639px  circle 14.375rem + ml-16(4rem)    = 18.375rem →  text -left-8
+					 *   640–767px  circle 16.875rem + ml-16(4rem)    = 20.875rem →  text -left-12
 					 *   768px+     circle 22.5rem  + ml-0           = 22.5rem  →  text -left-[6.875rem]
 					 *   (1280px+   switches to 2-col grid via site-page.tsx)
 					 */}
-					<p className="absolute top-32 -left-6 -rotate-16 font-serif text-xl leading-tight font-semibold text-[#cccccc] min-[375px]:top-36 min-[375px]:-left-8 sm:top-52 sm:-left-12 sm:text-2xl md:top-[16.25rem] md:-left-[6.875rem] md:text-3xl">
+					<p className="absolute top-32 -left-6 -rotate-16 font-serif text-xl leading-tight font-semibold text-[#cccccc] min-[375px]:top-[10.375rem] min-[375px]:-left-[0.875rem] min-[375px]:-rotate-[22deg] min-[375px]:text-2xl sm:top-52 sm:-left-12 sm:text-2xl md:top-[16.25rem] md:-left-[6.875rem] md:text-3xl">
 						Let me
 						<br />
 						introduce
@@ -72,7 +81,7 @@ export function VideoHeroSectionClient({
 					{/* Main circle area */}
 					<div className="relative ml-10 min-[375px]:ml-16 md:ml-0">
 						{/* circle.gif — animated ring overlay */}
-						<div className="relative size-[12.5rem] min-[375px]:size-[13.75rem] sm:size-[16.875rem] md:size-[22.5rem]">
+						<div className="relative size-[13.125rem] min-[375px]:size-[15.9375rem] min-[425px]:size-[17.8125rem] sm:size-[16.875rem] md:size-[22.5rem]">
 							<Image
 								src="/circle.gif"
 								alt=""
@@ -84,19 +93,20 @@ export function VideoHeroSectionClient({
 
 						{/* Circular video — positioned inside the ring */}
 						<div className="absolute inset-0 z-0 flex items-center justify-center">
-							<div className="relative size-[10.3125rem] translate-x-1 overflow-hidden rounded-full min-[375px]:size-[11.25rem] sm:size-56 md:size-[19.1875rem]">
+							<div className="relative size-[11.25rem] translate-x-1 overflow-hidden rounded-full min-[375px]:size-[13.75rem] min-[425px]:size-[15.625rem] sm:size-56 md:size-[19.1875rem]">
 								<video
 									ref={videoRef}
 									muted
-									loop
 									playsInline
+									poster={heroPosterUrl || undefined}
 									className="absolute inset-0 size-full object-cover"
-									onEnded={() => setIsPlaying(false)}
+									onEnded={handleEnded}
 								>
-									<source
-										src="/Intro.mov"
-										type="video/mp4"
-									/>
+									{heroVideoUrl ? (
+										<source src={heroVideoUrl} type="video/mp4" />
+									) : (
+										<source src="/Intro.mov" type="video/mp4" />
+									)}
 								</video>
 							</div>
 						</div>
@@ -124,15 +134,12 @@ export function VideoHeroSectionClient({
 								<Play className="size-8 fill-white text-white" />
 							)}
 						</button>
+
 					</div>
 				</div>
 
-				{/* tablet+ — inside the inner div so it inherits the translate and items-center */}
-				<Caption className="hidden md:block" />
+				<Caption />
 			</div>
-
-			{/* mobile only — at section level with self-center to escape items-end */}
-			<Caption className="self-center md:hidden" />
 		</section>
 	);
 }

--- a/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
+++ b/src/app/(site)/(home)/_components/video-hero-section/video-hero-section-client.tsx
@@ -23,6 +23,30 @@ export function VideoHeroSectionClient({
 		setIsPlaying(!isPlaying);
 	}
 
+	// Caption rendered in two places: mobile (section-level, self-centered) and
+	// md+ (inside inner div, original flow). CSS show/hide keeps only one visible.
+	function Caption({ className }: { className?: string }) {
+		const splitWord = " but ";
+		const idx = availabilityMessage.toLowerCase().indexOf(splitWord);
+		const content =
+			idx === -1 ? (
+				`(${availabilityMessage})`
+			) : (
+				<>
+					({availabilityMessage.slice(0, idx + 4)}
+					<br />
+					{availabilityMessage.slice(idx + 5)})
+				</>
+			);
+		return (
+			<p
+				className={`mt-4 text-center font-serif text-base font-semibold text-[#cccccc] md:text-xl${className ? ` ${className}` : ""}`}
+			>
+				{content}
+			</p>
+		);
+	}
+
 	return (
 		<section className="flex flex-col items-end md:items-center xl:items-end">
 			<div className="flex flex-col items-center md:translate-x-[7.8125rem] xl:translate-x-0">
@@ -103,27 +127,12 @@ export function VideoHeroSectionClient({
 					</div>
 				</div>
 
-				{/* Disclaimer text — centered under the circle.
-				    Force line break after "but" so all viewports show:
-				    "(I am no longer looking for a job but
-				     keeping this video up)" */}
-				<p className="mt-4 text-center font-serif text-base font-semibold text-[#cccccc] md:text-xl">
-					{(() => {
-						const splitWord = " but ";
-						const idx = availabilityMessage.toLowerCase().indexOf(splitWord);
-						if (idx === -1) return `(${availabilityMessage})`;
-						const before = availabilityMessage.slice(0, idx + 4); // includes "but"
-						const after = availabilityMessage.slice(idx + 5); // after "but "
-						return (
-							<>
-								({before}
-								<br />
-								{after})
-							</>
-						);
-					})()}
-				</p>
+				{/* tablet+ — inside the inner div so it inherits the translate and items-center */}
+				<Caption className="hidden md:block" />
 			</div>
+
+			{/* mobile only — at section level with self-center to escape items-end */}
+			<Caption className="self-center md:hidden" />
 		</section>
 	);
 }

--- a/src/app/(site)/(home)/page.tsx
+++ b/src/app/(site)/(home)/page.tsx
@@ -1,9 +1,5 @@
-"use cache";
-
-import { cachePageLife } from "@/lib/caching";
 import { SitePage } from "../_components/site-page";
 
 export default async function Page() {
-	cachePageLife();
 	return <SitePage initialSection="about" />;
 }

--- a/src/app/(site)/_components/site-page.tsx
+++ b/src/app/(site)/_components/site-page.tsx
@@ -34,7 +34,7 @@ export async function SitePage({
 		<main className="flex flex-col">
 			<section
 				id="about"
-				className="mx-auto flex w-full max-w-5xl flex-col gap-16 pt-[7.5rem] pb-20"
+				className="mx-auto flex w-full max-w-5xl flex-col gap-16 pt-10 md:pt-20 xl:pt-[7.5rem] pb-20"
 			>
 				<div className="flex flex-col-reverse gap-16 px-6 md:px-[1.125rem] xl:grid xl:grid-cols-2 xl:items-start xl:gap-16">
 					<IntroSection />

--- a/src/app/(site)/_components/site-page.tsx
+++ b/src/app/(site)/_components/site-page.tsx
@@ -17,11 +17,12 @@ function BlogsSection() {
 	);
 }
 
-const SECTION_REGISTRY: Partial<Record<HomeSectionKey, () => React.ReactNode>> = {
-	experience: ExperienceSection,
-	otherWorks: OtherWorksSection,
-	testimonials: TestimonialsSection,
-};
+const SECTION_REGISTRY: Partial<Record<HomeSectionKey, () => React.ReactNode>> =
+	{
+		experience: ExperienceSection,
+		otherWorks: OtherWorksSection,
+		testimonials: TestimonialsSection,
+	};
 
 export async function SitePage({
 	initialSection = "about",
@@ -34,7 +35,7 @@ export async function SitePage({
 		<main className="flex flex-col">
 			<section
 				id="about"
-				className="mx-auto flex w-full max-w-5xl flex-col gap-16 pt-10 md:pt-20 xl:pt-[7.5rem] pb-20"
+				className="mx-auto flex w-full max-w-5xl flex-col gap-16 pt-10 pb-20 md:pt-20 xl:pt-[7.5rem]"
 			>
 				<div className="flex flex-col-reverse gap-16 px-6 md:px-[1.125rem] xl:grid xl:grid-cols-2 xl:items-start xl:gap-16">
 					<IntroSection />

--- a/src/app/(site)/work/_components/work-section/company-header.tsx
+++ b/src/app/(site)/work/_components/work-section/company-header.tsx
@@ -44,12 +44,10 @@ export function CompanyHeader({
 						</p>
 					)}
 					{workDescription && (
-						<div className="text-base leading-prose font-light tracking-prose text-paragraph">
-							<PortableTextRenderer
-								value={workDescription}
-								variant="base"
-							/>
-						</div>
+						<PortableTextRenderer
+							value={workDescription}
+							variant="article"
+						/>
 					)}
 				</div>
 			)}

--- a/src/app/(site)/work/page.tsx
+++ b/src/app/(site)/work/page.tsx
@@ -1,9 +1,5 @@
-"use cache";
-
-import { cachePageLife } from "@/lib/caching";
 import { SitePage } from "../_components/site-page";
 
 export default async function WorkPage() {
-	cachePageLife();
 	return <SitePage initialSection="work" />;
 }

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -4,6 +4,25 @@ import { parseBody } from "next-sanity/webhook";
 import { revalidateTag } from "next/cache";
 import { type NextRequest, NextResponse } from "next/server";
 
+/**
+ * Development-only: flush all cache tags without a webhook signature.
+ * Hit GET /api/revalidate in the browser after publishing in Sanity Studio.
+ * Returns 404 in production.
+ */
+export async function GET() {
+	if (process.env.NODE_ENV !== "development") {
+		return NextResponse.json({ error: "Not found" }, { status: 404 });
+	}
+
+	for (const tags of Object.values(DOCUMENT_TYPE_TO_TAGS)) {
+		for (const tag of tags) {
+			revalidateTag(tag, "max");
+		}
+	}
+
+	return NextResponse.json({ revalidated: true, message: "All cache tags flushed" });
+}
+
 interface SanityWebhookPayload {
 	_type: keyof typeof DOCUMENT_TYPE_TO_TAGS;
 	_id: string;

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -67,7 +67,6 @@ export async function POST(request: NextRequest) {
 			});
 		}
 
-		// Revalidate with stale-while-revalidate behavior
 		for (const tag of tags) {
 			revalidateTag(tag, "max");
 		}

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -20,7 +20,10 @@ export async function GET() {
 		}
 	}
 
-	return NextResponse.json({ revalidated: true, message: "All cache tags flushed" });
+	return NextResponse.json({
+		revalidated: true,
+		message: "All cache tags flushed",
+	});
 }
 
 interface SanityWebhookPayload {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,24 +32,6 @@
 	--radius-2xl: calc(var(--radius) + 8px);
 	--radius-3xl: calc(var(--radius) + 12px);
 	--radius-4xl: calc(var(--radius) + 16px);
-	--animate-fade-in-up: fade-in-up 0.75s ease-out both;
-}
-
-@keyframes fade-in-up {
-	from {
-		opacity: 0;
-		transform: translateY(3rem);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
-}
-
-@layer utilities {
-	.animate-fade-in-up {
-		animation: fade-in-up 0.75s ease-out both;
-	}
 }
 
 :root {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,24 @@
 	--radius-2xl: calc(var(--radius) + 8px);
 	--radius-3xl: calc(var(--radius) + 12px);
 	--radius-4xl: calc(var(--radius) + 16px);
+	--animate-fade-in-up: fade-in-up 0.75s ease-out both;
+}
+
+@keyframes fade-in-up {
+	from {
+		opacity: 0;
+		transform: translateY(3rem);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}
+
+@layer utilities {
+	.animate-fade-in-up {
+		animation: fade-in-up 0.75s ease-out both;
+	}
 }
 
 :root {

--- a/src/components/SplitText.tsx
+++ b/src/components/SplitText.tsx
@@ -111,9 +111,17 @@ const SplitText: FC<SplitTextProps> = ({
 				onSplit: (self: any) => {
 					if (splitType.includes("chars") && self.chars?.length)
 						targets = self.chars;
-					if (!targets.length && splitType.includes("words") && self.words.length)
+					if (
+						!targets.length &&
+						splitType.includes("words") &&
+						self.words.length
+					)
 						targets = self.words;
-					if (!targets.length && splitType.includes("lines") && self.lines.length)
+					if (
+						!targets.length &&
+						splitType.includes("lines") &&
+						self.lines.length
+					)
 						targets = self.lines;
 					if (!targets.length) targets = self.chars || self.words || self.lines;
 
@@ -171,9 +179,21 @@ const SplitText: FC<SplitTextProps> = ({
 					undefined;
 			}
 		};
-	// JSON.stringify stabilises object identity for from/to without needing deep-equal
-	// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [text, delay, duration, ease, splitType, JSON.stringify(from), JSON.stringify(to), threshold, rootMargin, fontsLoaded, startDelay]);
+		// JSON.stringify stabilises object identity for from/to without needing deep-equal
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [
+		text,
+		delay,
+		duration,
+		ease,
+		splitType,
+		JSON.stringify(from),
+		JSON.stringify(to),
+		threshold,
+		rootMargin,
+		fontsLoaded,
+		startDelay,
+	]);
 
 	const style: CSSProperties = {
 		textAlign,

--- a/src/components/portable-text/base-components.tsx
+++ b/src/components/portable-text/base-components.tsx
@@ -12,9 +12,7 @@ import { inlineMarks } from "./inline-marks";
  * (e.g. `text-paragraph` on the company description container). Decorators
  * override per-span.
  */
-const asP = ({ children }: { children?: React.ReactNode }) => (
-	<p>{children}</p>
-);
+const asP = ({ children }: { children?: React.ReactNode }) => <p>{children}</p>;
 
 export const baseComponents: PortableTextComponents = {
 	block: {

--- a/src/components/portable-text/base-components.tsx
+++ b/src/components/portable-text/base-components.tsx
@@ -12,9 +12,19 @@ import { inlineMarks } from "./inline-marks";
  * (e.g. `text-paragraph` on the company description container). Decorators
  * override per-span.
  */
+const asP = ({ children }: { children?: React.ReactNode }) => (
+	<p>{children}</p>
+);
+
 export const baseComponents: PortableTextComponents = {
 	block: {
-		normal: ({ children }) => <p>{children}</p>,
+		normal: asP,
+		h1: asP,
+		h2: asP,
+		h3: asP,
+		h4: asP,
+		h5: asP,
+		h6: asP,
 	},
 	marks: inlineMarks,
 	listItem: {

--- a/src/components/portable-text/index.ts
+++ b/src/components/portable-text/index.ts
@@ -1,6 +1,7 @@
 export { articleComponents } from "./article-components";
 export { baseComponents } from "./base-components";
 export {
+	ARTICLE_PROSE,
 	PortableTextRenderer,
 	type PortableTextVariant,
 } from "./portable-text-renderer";

--- a/src/components/portable-text/portable-text-renderer.tsx
+++ b/src/components/portable-text/portable-text-renderer.tsx
@@ -57,7 +57,7 @@ function annotateNumberedListSequence<T extends { _type?: string }>(
  * hierarchy body < h6 < h5 < h4 < h3 < h2 < h1 reads cleanly at every
  * breakpoint without the headings collapsing into the paragraph size.
  */
-const ARTICLE_PROSE = [
+export const ARTICLE_PROSE = [
 	"prose prose-neutral max-w-none font-sans",
 
 	// Responsive text sizes.

--- a/src/lib/caching.ts
+++ b/src/lib/caching.ts
@@ -38,12 +38,11 @@ export function cachePageLife() {
 }
 
 /**
- * Tag a resource with the cache tags for a given document type
- * Applies "use cache" + cacheTag() + cacheLife() pattern
+ * Apply the default cache life and tags inside an existing "use cache" boundary.
  */
-export async function tagResource(type: keyof typeof DOCUMENT_TYPE_TO_TAGS) {
-	"use cache";
-
+export function cacheSanityResource(
+	...types: Array<keyof typeof DOCUMENT_TYPE_TO_TAGS>
+) {
 	cacheLife(CACHE_LIFE);
-	cacheTag(getTags(type)[0]);
+	cacheTag(...types.flatMap(getTags));
 }

--- a/src/lib/media/cloudinary.service.ts
+++ b/src/lib/media/cloudinary.service.ts
@@ -30,6 +30,10 @@ export class CloudinaryMediaService {
 		return this.buildUrl(asset, transforms);
 	}
 
+	getVideoPosterUrl(asset: CloudinaryAsset): string {
+		return this.buildUrl({ ...asset, format: "jpg" }, "so_0,f_jpg,q_auto:best");
+	}
+
 	/**
 	 * Build Cloudinary URL with transformations
 	 * Format: https://res.cloudinary.com/{cloud}/{resource_type}/{type}/{transforms}/{public_id}

--- a/src/lib/media/cloudinary.service.ts
+++ b/src/lib/media/cloudinary.service.ts
@@ -31,7 +31,7 @@ export class CloudinaryMediaService {
 	}
 
 	getVideoPosterUrl(asset: CloudinaryAsset): string {
-		return this.buildUrl({ ...asset, format: "jpg" }, "so_0,f_jpg,q_auto:best");
+		return this.buildUrl({ ...asset, format: "jpg" }, "so_0,q_auto:best");
 	}
 
 	/**

--- a/src/lib/media/index.ts
+++ b/src/lib/media/index.ts
@@ -24,6 +24,14 @@ export function getCloudinaryService(): CloudinaryMediaService {
  * Cloudinary URL (public_id / resource_type / type). Callers should treat ""
  * as "no asset" — `<MediaImage src="">` renders nothing.
  */
+export function getVideoPosterUrl(
+	asset: CloudinaryAsset | undefined | null,
+): string {
+	if (!asset?.public_id || !asset.resource_type || !asset.type) return "";
+	const service = getCloudinaryService();
+	return service.getVideoPosterUrl(asset);
+}
+
 export function getMediaUrl(
 	asset: CloudinaryAsset | undefined | null,
 	options?: { width?: number; height?: number },

--- a/src/sanity/lib/dal.ts
+++ b/src/sanity/lib/dal.ts
@@ -1,5 +1,6 @@
 import { tagResource } from "@/lib/caching";
-import { getMediaUrl } from "@/lib/media";
+import type { CloudinaryAsset } from "@/lib/media";
+import { getMediaUrl, getVideoPosterUrl } from "@/lib/media";
 import type { PortableTextBlock } from "next-sanity";
 import "server-only";
 import type {
@@ -111,6 +112,8 @@ export interface SiteProfileDTO {
 	title: PortableTextBlock[];
 	bio: PortableTextBlock[];
 	availabilityMessage: string;
+	heroVideoUrl: string;
+	heroPosterUrl: string;
 }
 
 export interface WorkItemDTO {
@@ -521,11 +524,14 @@ export async function getSiteProfile(): Promise<SiteProfileDTO | null> {
 	});
 	if (!profile) return null;
 
+	const heroVideo = (profile as unknown as { heroVideo?: CloudinaryAsset | null }).heroVideo;
 	return {
 		name: (profile.name ?? []) as unknown as PortableTextBlock[],
 		title: (profile.title ?? []) as unknown as PortableTextBlock[],
 		bio: (profile.bio ?? []) as unknown as PortableTextBlock[],
 		availabilityMessage: profile.availabilityMessage ?? "",
+		heroVideoUrl: getMediaUrl(heroVideo),
+		heroPosterUrl: getVideoPosterUrl(heroVideo),
 	};
 }
 

--- a/src/sanity/lib/dal.ts
+++ b/src/sanity/lib/dal.ts
@@ -1,6 +1,7 @@
-import { tagResource } from "@/lib/caching";
+import { CACHE_LIFE, tagResource } from "@/lib/caching";
 import { getMediaUrl, getVideoPosterUrl } from "@/lib/media";
 import type { PortableTextBlock } from "next-sanity";
+import { cacheLife, cacheTag } from "next/cache";
 import "server-only";
 import type {
 	AllWorkItemSlugsQueryResult,
@@ -547,8 +548,10 @@ export async function getSectionHeader(
 }
 
 export async function getWorkPageCompanies(): Promise<WorkPageCompanyDTO[]> {
-	await tagResource("workItem");
-	await tagResource("company");
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("workItems");
+	cacheTag("companies");
 
 	const companies = await sanityFetch<WorkPageQueryResult>({
 		query: workPageQuery,
@@ -559,11 +562,13 @@ export async function getWorkPageCompanies(): Promise<WorkPageCompanyDTO[]> {
 export async function getWorkItemBySlug(
 	slug: string,
 ): Promise<WorkItemDetailDTO | null> {
+	"use cache";
 	// Tag all three — the detail page embeds testimonial references inline, so
 	// edits to an embedded testimonial doc should bust this page's cache.
-	await tagResource("workItem");
-	await tagResource("company");
-	await tagResource("testimonial");
+	cacheLife(CACHE_LIFE);
+	cacheTag("workItems");
+	cacheTag("companies");
+	cacheTag("testimonials");
 
 	const data = await sanityFetch<WorkItemBySlugQueryResult>({
 		query: workItemBySlugQuery,
@@ -574,7 +579,9 @@ export async function getWorkItemBySlug(
 }
 
 export async function getAllWorkItemSlugs(): Promise<string[]> {
-	await tagResource("workItem");
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("workItems");
 
 	const slugs = await sanityFetch<AllWorkItemSlugsQueryResult>({
 		query: allWorkItemSlugsQuery,

--- a/src/sanity/lib/dal.ts
+++ b/src/sanity/lib/dal.ts
@@ -524,9 +524,9 @@ export async function getSiteProfile(): Promise<SiteProfileDTO | null> {
 	if (!profile) return null;
 
 	return {
-		name: (profile.name ?? []) as unknown as PortableTextBlock[],
-		title: (profile.title ?? []) as unknown as PortableTextBlock[],
-		bio: (profile.bio ?? []) as unknown as PortableTextBlock[],
+		name: (profile.name ?? []) as PortableTextBlock[],
+		title: (profile.title ?? []) as PortableTextBlock[],
+		bio: (profile.bio ?? []) as PortableTextBlock[],
 		availabilityMessage: profile.availabilityMessage ?? "",
 		heroVideoUrl: getMediaUrl(profile.heroVideo),
 		heroPosterUrl: getVideoPosterUrl(profile.heroVideo),

--- a/src/sanity/lib/dal.ts
+++ b/src/sanity/lib/dal.ts
@@ -1,5 +1,4 @@
 import { tagResource } from "@/lib/caching";
-import type { CloudinaryAsset } from "@/lib/media";
 import { getMediaUrl, getVideoPosterUrl } from "@/lib/media";
 import type { PortableTextBlock } from "next-sanity";
 import "server-only";
@@ -524,14 +523,13 @@ export async function getSiteProfile(): Promise<SiteProfileDTO | null> {
 	});
 	if (!profile) return null;
 
-	const heroVideo = (profile as unknown as { heroVideo?: CloudinaryAsset | null }).heroVideo;
 	return {
 		name: (profile.name ?? []) as unknown as PortableTextBlock[],
 		title: (profile.title ?? []) as unknown as PortableTextBlock[],
 		bio: (profile.bio ?? []) as unknown as PortableTextBlock[],
 		availabilityMessage: profile.availabilityMessage ?? "",
-		heroVideoUrl: getMediaUrl(heroVideo),
-		heroPosterUrl: getVideoPosterUrl(heroVideo),
+		heroVideoUrl: getMediaUrl(profile.heroVideo),
+		heroPosterUrl: getVideoPosterUrl(profile.heroVideo),
 	};
 }
 

--- a/src/sanity/lib/dal.ts
+++ b/src/sanity/lib/dal.ts
@@ -1,7 +1,7 @@
-import { CACHE_LIFE, tagResource } from "@/lib/caching";
+import { CACHE_LIFE } from "@/lib/caching";
 import { getMediaUrl, getVideoPosterUrl } from "@/lib/media";
-import type { PortableTextBlock } from "next-sanity";
 import { cacheLife, cacheTag } from "next/cache";
+import type { PortableTextBlock } from "next-sanity";
 import "server-only";
 import type {
 	AllWorkItemSlugsQueryResult,
@@ -472,8 +472,9 @@ function toWorkItemDetailDTO(data: WorkItemDetailRaw): WorkItemDetailDTO {
  */
 
 export async function getTestimonials(): Promise<TestimonialDTO[]> {
-	await tagResource("testimonial");
-
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("testimonials");
 	const testimonials = await sanityFetch<TestimonialsQueryResult>({
 		query: testimonialsQuery,
 	});
@@ -481,8 +482,9 @@ export async function getTestimonials(): Promise<TestimonialDTO[]> {
 }
 
 export async function getCompanies(): Promise<CompanyDTO[]> {
-	await tagResource("company");
-
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("companies");
 	const companies = await sanityFetch<CompaniesQueryResult>({
 		query: companiesQuery,
 	});
@@ -490,8 +492,9 @@ export async function getCompanies(): Promise<CompanyDTO[]> {
 }
 
 export async function getSocials(): Promise<SocialDTO[]> {
-	await tagResource("social");
-
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("socials");
 	const socials = await sanityFetch<SocialsQueryResult>({
 		query: socialsQuery,
 	});
@@ -499,8 +502,9 @@ export async function getSocials(): Promise<SocialDTO[]> {
 }
 
 export async function getProjects(): Promise<ProjectDTO[]> {
-	await tagResource("project");
-
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("projects");
 	const projects = await sanityFetch<ProjectsQueryResult>({
 		query: projectsQuery,
 	});
@@ -508,8 +512,9 @@ export async function getProjects(): Promise<ProjectDTO[]> {
 }
 
 export async function getExperiences(): Promise<ExperienceDTO[]> {
-	await tagResource("experience");
-
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("experiences");
 	const experiences = await sanityFetch<ExperiencesQueryResult>({
 		query: experiencesQuery,
 	});
@@ -517,8 +522,9 @@ export async function getExperiences(): Promise<ExperienceDTO[]> {
 }
 
 export async function getSiteProfile(): Promise<SiteProfileDTO | null> {
-	await tagResource("siteProfile");
-
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("siteProfile");
 	const profile = await sanityFetch<SiteProfileQueryResult>({
 		query: siteProfileQuery,
 	});
@@ -537,8 +543,9 @@ export async function getSiteProfile(): Promise<SiteProfileDTO | null> {
 export async function getSectionHeader(
 	slug: string,
 ): Promise<SectionHeaderDTO | null> {
-	await tagResource("sectionHeader");
-
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("sectionHeaders");
 	const header = await sanityFetch<SectionHeaderQueryResult>({
 		query: sectionHeaderQuery,
 		params: { slug },
@@ -550,9 +557,7 @@ export async function getSectionHeader(
 export async function getWorkPageCompanies(): Promise<WorkPageCompanyDTO[]> {
 	"use cache";
 	cacheLife(CACHE_LIFE);
-	cacheTag("workItems");
-	cacheTag("companies");
-
+	cacheTag("workItems", "companies");
 	const companies = await sanityFetch<WorkPageQueryResult>({
 		query: workPageQuery,
 	});
@@ -563,13 +568,8 @@ export async function getWorkItemBySlug(
 	slug: string,
 ): Promise<WorkItemDetailDTO | null> {
 	"use cache";
-	// Tag all three — the detail page embeds testimonial references inline, so
-	// edits to an embedded testimonial doc should bust this page's cache.
 	cacheLife(CACHE_LIFE);
-	cacheTag("workItems");
-	cacheTag("companies");
-	cacheTag("testimonials");
-
+	cacheTag("workItems", "companies", "testimonials");
 	const data = await sanityFetch<WorkItemBySlugQueryResult>({
 		query: workItemBySlugQuery,
 		params: { slug },
@@ -582,7 +582,6 @@ export async function getAllWorkItemSlugs(): Promise<string[]> {
 	"use cache";
 	cacheLife(CACHE_LIFE);
 	cacheTag("workItems");
-
 	const slugs = await sanityFetch<AllWorkItemSlugsQueryResult>({
 		query: allWorkItemSlugsQuery,
 	});
@@ -592,8 +591,9 @@ export async function getAllWorkItemSlugs(): Promise<string[]> {
 const DEFAULT_HOME_SECTIONS: readonly HomeSectionKey[] = HOME_SECTION_KEYS;
 
 export async function getHomePageSections(): Promise<HomeSectionKey[]> {
-	await tagResource("homePage");
-
+	"use cache";
+	cacheLife(CACHE_LIFE);
+	cacheTag("homePage");
 	const data = await sanityFetch<HomePageQueryResult>({
 		query: homePageQuery,
 	});

--- a/src/sanity/lib/dal.ts
+++ b/src/sanity/lib/dal.ts
@@ -1,6 +1,5 @@
-import { CACHE_LIFE } from "@/lib/caching";
+import { cacheSanityResource } from "@/lib/caching";
 import { getMediaUrl, getVideoPosterUrl } from "@/lib/media";
-import { cacheLife, cacheTag } from "next/cache";
 import type { PortableTextBlock } from "next-sanity";
 import "server-only";
 import type {
@@ -473,8 +472,7 @@ function toWorkItemDetailDTO(data: WorkItemDetailRaw): WorkItemDetailDTO {
 
 export async function getTestimonials(): Promise<TestimonialDTO[]> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("testimonials");
+	cacheSanityResource("testimonial");
 	const testimonials = await sanityFetch<TestimonialsQueryResult>({
 		query: testimonialsQuery,
 	});
@@ -483,8 +481,7 @@ export async function getTestimonials(): Promise<TestimonialDTO[]> {
 
 export async function getCompanies(): Promise<CompanyDTO[]> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("companies");
+	cacheSanityResource("company");
 	const companies = await sanityFetch<CompaniesQueryResult>({
 		query: companiesQuery,
 	});
@@ -493,8 +490,7 @@ export async function getCompanies(): Promise<CompanyDTO[]> {
 
 export async function getSocials(): Promise<SocialDTO[]> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("socials");
+	cacheSanityResource("social");
 	const socials = await sanityFetch<SocialsQueryResult>({
 		query: socialsQuery,
 	});
@@ -503,8 +499,7 @@ export async function getSocials(): Promise<SocialDTO[]> {
 
 export async function getProjects(): Promise<ProjectDTO[]> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("projects");
+	cacheSanityResource("project");
 	const projects = await sanityFetch<ProjectsQueryResult>({
 		query: projectsQuery,
 	});
@@ -513,8 +508,7 @@ export async function getProjects(): Promise<ProjectDTO[]> {
 
 export async function getExperiences(): Promise<ExperienceDTO[]> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("experiences");
+	cacheSanityResource("experience");
 	const experiences = await sanityFetch<ExperiencesQueryResult>({
 		query: experiencesQuery,
 	});
@@ -523,8 +517,7 @@ export async function getExperiences(): Promise<ExperienceDTO[]> {
 
 export async function getSiteProfile(): Promise<SiteProfileDTO | null> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("siteProfile");
+	cacheSanityResource("siteProfile");
 	const profile = await sanityFetch<SiteProfileQueryResult>({
 		query: siteProfileQuery,
 	});
@@ -544,8 +537,7 @@ export async function getSectionHeader(
 	slug: string,
 ): Promise<SectionHeaderDTO | null> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("sectionHeaders");
+	cacheSanityResource("sectionHeader");
 	const header = await sanityFetch<SectionHeaderQueryResult>({
 		query: sectionHeaderQuery,
 		params: { slug },
@@ -556,8 +548,7 @@ export async function getSectionHeader(
 
 export async function getWorkPageCompanies(): Promise<WorkPageCompanyDTO[]> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("workItems", "companies");
+	cacheSanityResource("workItem", "company");
 	const companies = await sanityFetch<WorkPageQueryResult>({
 		query: workPageQuery,
 	});
@@ -568,8 +559,7 @@ export async function getWorkItemBySlug(
 	slug: string,
 ): Promise<WorkItemDetailDTO | null> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("workItems", "companies", "testimonials");
+	cacheSanityResource("workItem", "company", "testimonial");
 	const data = await sanityFetch<WorkItemBySlugQueryResult>({
 		query: workItemBySlugQuery,
 		params: { slug },
@@ -580,8 +570,7 @@ export async function getWorkItemBySlug(
 
 export async function getAllWorkItemSlugs(): Promise<string[]> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("workItems");
+	cacheSanityResource("workItem");
 	const slugs = await sanityFetch<AllWorkItemSlugsQueryResult>({
 		query: allWorkItemSlugsQuery,
 	});
@@ -592,8 +581,7 @@ const DEFAULT_HOME_SECTIONS: readonly HomeSectionKey[] = HOME_SECTION_KEYS;
 
 export async function getHomePageSections(): Promise<HomeSectionKey[]> {
 	"use cache";
-	cacheLife(CACHE_LIFE);
-	cacheTag("homePage");
+	cacheSanityResource("homePage");
 	const data = await sanityFetch<HomePageQueryResult>({
 		query: homePageQuery,
 	});

--- a/src/sanity/lib/fetch.ts
+++ b/src/sanity/lib/fetch.ts
@@ -2,16 +2,19 @@ import type { QueryParams } from "sanity";
 import "server-only";
 import { client } from "./client";
 
-/**
- * Sanity fetch wrapper
- * **Note**: Caching is handled at the DAL level with "use cache" + cacheTag() + cacheLife()
- */
+const isDev = process.env.NODE_ENV === "development";
+
 export async function sanityFetch<T>({
 	query,
 	params = {},
+	tags = [],
 }: {
 	query: string;
 	params?: QueryParams;
+	tags?: string[];
 }): Promise<T> {
-	return client.fetch<T>(query, params);
+	return client.fetch<T>(query, params, {
+		cache: isDev ? "no-store" : "force-cache",
+		next: isDev ? undefined : { tags },
+	});
 }

--- a/src/sanity/lib/queries.ts
+++ b/src/sanity/lib/queries.ts
@@ -61,7 +61,8 @@ export const siteProfileQuery = groq`
     name,
     title,
     bio,
-    availabilityMessage
+    availabilityMessage,
+    heroVideo
   }
 `;
 

--- a/src/sanity/schemaTypes/company.ts
+++ b/src/sanity/schemaTypes/company.ts
@@ -1,5 +1,6 @@
 import { CaseIcon } from "@sanity/icons";
 import { defineField, defineType } from "sanity";
+import { CaseStudyContentPlugins } from "../components/case-study-content";
 import { articleBlock } from "../rich-text";
 
 export const company = defineType({
@@ -52,6 +53,11 @@ export const company = defineType({
 			title: "Work Description",
 			type: "array",
 			of: [articleBlock()],
+			components: {
+				portableText: {
+					plugins: CaseStudyContentPlugins,
+				},
+			},
 			description:
 				"Description shown on the work page. Use the colorForeground decorator to highlight phrases against the dimmed paragraph color.",
 		}),

--- a/src/sanity/schemaTypes/siteProfile.ts
+++ b/src/sanity/schemaTypes/siteProfile.ts
@@ -45,7 +45,8 @@ export const siteProfile = defineType({
 			name: "heroVideo",
 			title: "Hero Video",
 			type: "cloudinary.asset",
-			description: "Video shown in the circular video player on the home page hero section",
+			description:
+				"Video shown in the circular video player on the home page hero section",
 		}),
 		defineField({
 			name: "bio",

--- a/src/sanity/schemaTypes/siteProfile.ts
+++ b/src/sanity/schemaTypes/siteProfile.ts
@@ -42,6 +42,12 @@ export const siteProfile = defineType({
 			validation: (rule) => rule.required(),
 		}),
 		defineField({
+			name: "heroVideo",
+			title: "Hero Video",
+			type: "cloudinary.asset",
+			description: "Video shown in the circular video player on the home page hero section",
+		}),
+		defineField({
 			name: "bio",
 			title: "Biography",
 			type: "array",


### PR DESCRIPTION
## Summary

- **Responsive layout fixes** for the video hero section across all mobile breakpoints (S/M/L), including circle sizes, caption alignment, "Let me introduce myself" text position, and section padding
- **Cloudinary video integration** — hero video is now managed via Sanity CMS (Site Profile → Hero Video), with automatic thumbnail generation used as the `poster` before playback and after the video ends
- **Scroll animations** — per-paragraph bio text, hero name/title, and company logos all animate in on scroll with ease-out stagger (once-only, no scroll-out)
- **Carousel blur edges** — ProgressiveBlur + narrow gradient fade on desktop only (hidden on mobile) for Work and Testimonials carousels
- **Experience section heading sizes** — company name and role now respect Sanity heading levels (h1–h5) for font sizing
- **PR review fixes** — removed redundant `f_jpg` transform in `getVideoPosterUrl`, simplified video source conditional, eliminated unsafe type casts, added hero fallback text, fixed animation consistency, replaced hardcoded colors with semantic tokens, removed unused CSS utility

## Changes

### UI / Layout
- Fix `circle.gif` and inner video circle sizes at mobile S (`360px`), M (`375–424px`), and L (`425–639px`) breakpoints using precise `rem` values
- Rewrite caption centering: use matching `ml`/`w` classes between the caption and the circle container so `text-center` aligns under the circle at every breakpoint
- Tune "Let me introduce myself" text: position, rotation (`-rotate-[22deg]` on M/L), and size
- Reduce `#about` section top padding — `pt-10` mobile / `md:pt-20` tablet / `xl:pt-[7.5rem]` desktop
- Reduce horizontal padding on the video hero section to `16px` on mobile via `-mx-2`
- Caption typography: `18px` font size, `bold` (700), `19px` line height; two-line wrap on mobile S using conditional `<br>`

### Animations
- Add Framer Motion scroll-in animation to hero name and title (`once: true`, ease-out)
- Add per-paragraph stagger animation to bio text with `once: true` (no scroll-out)
- Add per-logo stagger animation to company logos via server/client component split (`once: true`)
- Export `ARTICLE_PROSE` from portable-text for external use by `AboutSection`

### Carousel Edges
- Add `ProgressiveBlur` (w-24) + narrow `w-8` gradient overlay on both edges of Work and Testimonials carousels
- Hidden on mobile (`hidden md:block`) — only active from `md` breakpoint up

### Experience Section
- Map Sanity heading levels (h1→`text-xl`, h2→`text-lg`, h3→`text-base`, h4→`text-sm`, h5→`text-xs`) to inline spans for company name and role fields

### Cloudinary Video Integration
- Add `heroVideo` (`cloudinary.asset`) field to the **Site Profile** Sanity schema
- Include `heroVideo` in `siteProfileQuery` and expose `heroVideoUrl` + `heroPosterUrl` from the DAL
- Fix `getVideoPosterUrl`: removed redundant `f_jpg` transform (`.jpg` extension already appended via `buildUrl`)
- `VideoHeroSectionClient` uses Cloudinary URL as source with `/Intro.mov` fallback
- Remove `loop`; `onEnded` resets to poster frame

### Code Quality
- Run `bun x sanity typegen generate` to eliminate unsafe casts — reduced `as unknown as PortableTextBlock[]` to `as PortableTextBlock[]`
- `HeroSection` falls back to "Karthik Panchala" / "Product Designer" when CMS data is absent
- Replace hardcoded `text-[#cccccc]` with `text-muted-foreground` in video hero section
- Remove unused `animate-fade-in-up` CSS utility and `@keyframes` block
- Simplify redundant video source conditional

## Test Plan
- [ ] Upload a video in Sanity Studio → Site Profile → Hero Video
- [ ] Run `bun run sanity:schema:deploy` to publish schema changes
- [ ] Verify poster image appears before play and after video ends
- [ ] Verify play/pause button works correctly
- [ ] Check layout on Mobile S (360px), M (375px), L (425px), tablet (768px), and desktop (1280px)
- [ ] Confirm fallback to `/Intro.mov` when no Cloudinary video is set
- [ ] Scroll bio/hero into view — confirm scroll-in animation plays once only
- [ ] Check carousel blur edges visible on desktop, absent on mobile
- [ ] Confirm hero name/title still renders when CMS profile is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)