### PR TITLE
feat: home page UX improvements

### DIFF
--- a/src/app/(site)/(home)/_components/other-works-section/other-works-carousel.tsx
+++ b/src/app/(site)/(home)/_components/other-works-section/other-works-carousel.tsx
@@ -57,7 +57,7 @@ export function OtherWorksCarousel({ projects }: OtherWorksCarouselProps) {
 					{displayedProjects.map((project, index) => (
 						<CarouselItem
 							key={`${project.name}-${index}`}
-							className="basis-[85%] md:basis-1/4 lg:basis-[40%]"
+							className="basis-auto"
 						>
 							<ProductCard
 								image={project.image}

--- a/src/app/(site)/(home)/_components/other-works-section/product-card.tsx
+++ b/src/app/(site)/(home)/_components/other-works-section/product-card.tsx
@@ -1,4 +1,3 @@
-import { MediaImage } from "@/components/media";
 import useIsMobile from "@/hooks/use-media-query";
 import { motion } from "motion/react";
 import React from "react";
@@ -22,18 +21,17 @@ export function ProductCard({
 
 	return (
 		<div
-			className="relative h-full cursor-pointer overflow-hidden rounded-[14px]"
+			className="relative h-[380px] cursor-pointer overflow-hidden rounded-[14px]"
 			style={{ backgroundColor }}
 			onMouseEnter={() => setIsHover(true)}
 			onMouseLeave={() => setIsHover(false)}
 			onClick={() => window.open(navigateUrl, "_blank")}
 		>
-			<MediaImage
+			{/* eslint-disable-next-line @next/next/no-img-element */}
+			<img
 				src={image}
 				alt={description}
-				width={296}
-				height={458}
-				className="size-full object-cover"
+				className="block h-full w-auto"
 			/>
 
 			<motion.div

--- a/src/app/(site)/(home)/_components/other-works-section/product-card.tsx
+++ b/src/app/(site)/(home)/_components/other-works-section/product-card.tsx
@@ -1,3 +1,4 @@
+import { MediaImage } from "@/components/media";
 import useIsMobile from "@/hooks/use-media-query";
 import { motion } from "motion/react";
 import React from "react";
@@ -27,10 +28,11 @@ export function ProductCard({
 			onMouseLeave={() => setIsHover(false)}
 			onClick={() => window.open(navigateUrl, "_blank")}
 		>
-			{/* eslint-disable-next-line @next/next/no-img-element */}
-			<img
+			<MediaImage
 				src={image}
 				alt={description}
+				width={400}
+				height={380}
 				className="block h-full w-auto"
 			/>
 

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
 
 	for (const tags of Object.values(DOCUMENT_TYPE_TO_TAGS)) {
 		for (const tag of tags) {
-			revalidateTag(tag, "max");
+			revalidateTag(tag, { expire: 0 });
 		}
 	}
 
@@ -71,7 +71,7 @@ export async function POST(request: NextRequest) {
 		}
 
 		for (const tag of tags) {
-			revalidateTag(tag, "max");
+			revalidateTag(tag, { expire: 0 });
 		}
 
 		return NextResponse.json({

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -32,7 +32,30 @@ export function Navbar() {
 		section: string,
 	) => {
 		e.preventDefault();
-		document.getElementById(section)?.scrollIntoView({ behavior: "smooth" });
+		const el = document.getElementById(section);
+		if (!el) return;
+
+		if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+			el.scrollIntoView();
+			return;
+		}
+
+		const startY = window.scrollY;
+		const targetY = el.getBoundingClientRect().top + startY;
+		const diff = targetY - startY;
+		const duration = 700;
+		let start: number | null = null;
+
+		const ease = (t: number) => (t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t);
+
+		const step = (timestamp: number) => {
+			if (!start) start = timestamp;
+			const progress = Math.min((timestamp - start) / duration, 1);
+			window.scrollTo(0, startY + diff * ease(progress));
+			if (progress < 1) requestAnimationFrame(step);
+		};
+
+		requestAnimationFrame(step);
 	};
 
 	const isHidden = activeSection === "about";

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -35,13 +35,21 @@ export function Navbar() {
 		document.getElementById(section)?.scrollIntoView({ behavior: "smooth" });
 	};
 
+	const isHidden = activeSection === "about";
+
 	return (
 		<nav
 			data-slot="navbar"
-			className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2"
+			className={cn(
+				"fixed bottom-6 left-1/2 z-50 -translate-x-1/2 transition-all duration-300",
+				isHidden
+					? "translate-y-20 opacity-0 pointer-events-none"
+					: "translate-y-0 opacity-100",
+			)}
 			aria-label="Main navigation"
+			aria-hidden={isHidden}
 		>
-			<div className="flex items-center rounded-full border border-border bg-card p-2">
+			<div className="flex items-center rounded-full border border-border bg-black px-[0.875rem] py-2 shadow-[0_4px_12px_rgba(0,0,0,0.5)]">
 				{NAV_ITEMS.map((item) => {
 					const isActive = activeSection === item.section;
 
@@ -51,7 +59,7 @@ export function Navbar() {
 							href={item.href}
 							onClick={(e) => handleClick(e, item.section)}
 							className={cn(
-								"rounded-full px-3.5 py-1.5 text-base font-semibold tracking-[0.32px] transition-colors",
+								"rounded-full px-3.5 py-1.5 text-lg font-semibold tracking-[0.32px] transition-colors",
 								isActive
 									? "text-foreground"
 									: "text-[oklch(70.94%_0_0)] hover:text-foreground/80",

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -49,7 +49,7 @@ export function Navbar() {
 			aria-label="Main navigation"
 			aria-hidden={isHidden}
 		>
-			<div className="flex items-center rounded-full border border-border bg-black px-[0.875rem] py-2 shadow-[0_4px_12px_rgba(0,0,0,0.5)]">
+			<div className="flex items-center rounded-full border border-border bg-background px-[0.875rem] py-2 shadow-[0_4px_12px_rgba(0,0,0,0.5)]">
 				{NAV_ITEMS.map((item) => {
 					const isActive = activeSection === item.section;
 

--- a/src/components/portable-text/portable-text-renderer.tsx
+++ b/src/components/portable-text/portable-text-renderer.tsx
@@ -86,7 +86,7 @@ export const ARTICLE_PROSE = [
 	"prose-h2:mt-0 prose-h2:mb-4",
 	"prose-h3:mt-0 prose-h3:mb-3",
 	"prose-h4:mt-0 prose-h4:mb-2",
-	"prose-h5:mt-0 prose-h5:mb-5",
+	"prose-h5:mt-0 prose-h5:mb-4",
 	"prose-h6:mt-0 prose-h6:mb-1",
 
 	// Paragraphs — only bottom margin so consecutive paragraphs don't double-stack

--- a/src/sanity/lib/fetch.ts
+++ b/src/sanity/lib/fetch.ts
@@ -10,6 +10,6 @@ export async function sanityFetch<T>({
 	params?: QueryParams;
 }): Promise<T> {
 	return client.fetch<T>(query, params, {
-		cache: "force-cache",
+		cache: process.env.NODE_ENV === "development" ? "no-store" : "force-cache",
 	});
 }

--- a/src/sanity/lib/fetch.ts
+++ b/src/sanity/lib/fetch.ts
@@ -2,19 +2,14 @@ import type { QueryParams } from "sanity";
 import "server-only";
 import { client } from "./client";
 
-const isDev = process.env.NODE_ENV === "development";
-
 export async function sanityFetch<T>({
 	query,
 	params = {},
-	tags = [],
 }: {
 	query: string;
 	params?: QueryParams;
-	tags?: string[];
 }): Promise<T> {
 	return client.fetch<T>(query, params, {
-		cache: isDev ? "no-store" : "force-cache",
-		next: isDev ? undefined : { tags },
+		cache: "force-cache",
 	});
 }


### PR DESCRIPTION
## Summary

- **Carousel layout**: Changed `CarouselItem` to `basis-auto` so each card sizes to its image's natural aspect ratio instead of fixed breakpoint-based widths
- **ProductCard**: Fixed height to `h-[380px]`; replaced `<img>` with `MediaImage` (project-standard Cloudinary component) using `h-full w-auto` for natural-width rendering — no eslint suppression needed
- **Navbar**: Hides with animated slide-out when user is on the "about" section (`translate-y-20 opacity-0 pointer-events-none`); added `aria-hidden` for accessibility; uses `bg-background` semantic token; increased nav item font size to `text-lg`
- **Cache revalidation**: Switched `revalidateTag` second arg from `"max"` (stale-while-revalidate) to `{ expire: 0 }` (hard purge) so webhook-triggered invalidations surface fresh content immediately
- **Sanity fetch**: Removed redundant `tags` param from `client.fetch` (tags now handled via `cacheTag()` in the DAL); restores `no-store` in development so Studio edits reflect without a manual cache flush
- **Prose spacing**: Minor `prose-h5` bottom margin tweak (`mb-5` → `mb-4`)

## Test plan

- [ ] Scroll past the about section — navbar should animate in; scroll back to about — navbar should slide out and become non-interactive
- [ ] Verify product cards in the "Other Works" carousel render at natural aspect-ratio widths, all 380px tall
- [ ] Publish a change in Sanity Studio and confirm it appears on the dev server without restarting
- [ ] Hit `GET /api/revalidate` in dev and confirm all cache tags flush; verify webhook endpoint still returns `revalidated: true` in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)