### PR TITLE
feat: add footer section with WhatsApp CTA

### DIFF
--- a/src/app/(site)/(home)/_components/footer-section/index.tsx
+++ b/src/app/(site)/(home)/_components/footer-section/index.tsx
@@ -18,7 +18,7 @@ function WhatsAppIcon() {
 
 export function FooterSection() {
 	return (
-		<footer className="w-full pb-28">
+		<footer className="w-full pb-20">
 			{/* Separator — full-width edge to edge */}
 			<hr id="footer-divider" className="border-border" />
 
@@ -44,8 +44,8 @@ export function FooterSection() {
 					<Image
 						src="/Flower.png"
 						alt=""
-						width={28}
-						height={42}
+						width={30}
+						height={44}
 						unoptimized
 						aria-hidden="true"
 					/>
@@ -56,13 +56,13 @@ export function FooterSection() {
 					href="https://wa.me/918008892112"
 					target="_blank"
 					rel="noopener noreferrer"
-					className="flex items-center rounded-full px-1.5 py-1.5 transition-opacity hover:opacity-90"
+					className="flex items-center rounded-full transition-opacity hover:opacity-90"
 					style={{ backgroundColor: "#25D467" }}
 					aria-label="Connect with Karthik on WhatsApp"
 				>
-					<span className="flex items-center gap-1.5 rounded-[50px] px-2 py-1.5">
+					<span className="flex items-center gap-1.5 px-4 py-3">
 						<WhatsAppIcon />
-						<span className="font-sans text-base font-semibold tracking-wide text-black">
+						<span className="font-sans text-base font-semibold tracking-wide text-white">
 							Connect on WhatsApp
 						</span>
 					</span>

--- a/src/app/(site)/(home)/_components/footer-section/index.tsx
+++ b/src/app/(site)/(home)/_components/footer-section/index.tsx
@@ -1,5 +1,8 @@
 import Image from "next/image";
 
+/** Shared ID for the footer divider — referenced by Navbar to stop above it. */
+export const FOOTER_DIVIDER_ID = "footer-divider";
+
 // WhatsApp SVG icon — inline so no external asset needed
 function WhatsAppIcon() {
 	return (
@@ -20,7 +23,7 @@ export function FooterSection() {
 	return (
 		<footer className="w-full pb-20">
 			{/* Separator — full-width edge to edge */}
-			<hr id="footer-divider" className="border-border" />
+			<hr id={FOOTER_DIVIDER_ID} className="border-border" />
 
 			{/* Content */}
 			<div className="mx-auto mt-10 flex max-w-5xl flex-col items-center gap-6 px-6 md:px-[1.125rem]">

--- a/src/app/(site)/(home)/_components/footer-section/index.tsx
+++ b/src/app/(site)/(home)/_components/footer-section/index.tsx
@@ -20,7 +20,7 @@ export function FooterSection() {
 	return (
 		<footer className="w-full pb-28">
 			{/* Separator — full-width edge to edge */}
-			<hr className="border-border" />
+			<hr id="footer-divider" className="border-border" />
 
 			{/* Content */}
 			<div className="mx-auto mt-10 flex max-w-5xl flex-col items-center gap-6 px-6 md:px-[1.125rem]">

--- a/src/app/(site)/(home)/_components/footer-section/index.tsx
+++ b/src/app/(site)/(home)/_components/footer-section/index.tsx
@@ -1,0 +1,75 @@
+import Image from "next/image";
+
+// WhatsApp SVG icon — inline so no external asset needed
+function WhatsAppIcon() {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			width={20}
+			height={20}
+			fill="white"
+			aria-hidden="true"
+		>
+			<path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+		</svg>
+	);
+}
+
+export function FooterSection() {
+	return (
+		<footer className="w-full pb-10">
+			{/* Separator */}
+			<div className="mx-auto max-w-5xl px-6 md:px-[1.125rem]">
+				<hr className="border-border" />
+			</div>
+
+			{/* Content */}
+			<div className="mx-auto mt-10 flex max-w-5xl flex-col items-center gap-6 px-6 md:px-[1.125rem]">
+				{/* Heading + Flower */}
+				<div className="flex items-start gap-3">
+					<p className="font-serif text-[28px] leading-normal">
+						<span className="font-normal text-foreground">{`Let's Work `}</span>
+						<span
+							className="font-semibold text-transparent"
+							style={{
+								backgroundImage:
+									"linear-gradient(-84deg, #FBBA27 13%, #FB7481 76%)",
+								WebkitBackgroundClip: "text",
+								backgroundClip: "text",
+							}}
+						>
+							together{" "}
+						</span>
+						<span className="font-normal text-foreground">:)</span>
+					</p>
+					<Image
+						src="/Flower.png"
+						alt=""
+						width={28}
+						height={42}
+						unoptimized
+						aria-hidden="true"
+					/>
+				</div>
+
+				{/* WhatsApp Button */}
+				<a
+					href="https://wa.me/918008892112"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="flex items-center rounded-full px-1.5 py-1.5 transition-opacity hover:opacity-90"
+					style={{ backgroundColor: "#25D467" }}
+					aria-label="Connect with Karthik on WhatsApp"
+				>
+					<span className="flex items-center gap-1.5 rounded-[50px] px-2 py-1.5">
+						<WhatsAppIcon />
+						<span className="font-sans text-base font-semibold tracking-wide text-black">
+							Connect on WhatsApp
+						</span>
+					</span>
+				</a>
+			</div>
+		</footer>
+	);
+}

--- a/src/app/(site)/(home)/_components/footer-section/index.tsx
+++ b/src/app/(site)/(home)/_components/footer-section/index.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
+import { FOOTER_DIVIDER_ID } from "@/lib/sections";
 
-/** Shared ID for the footer divider — referenced by Navbar to stop above it. */
-export const FOOTER_DIVIDER_ID = "footer-divider";
+export { FOOTER_DIVIDER_ID };
 
 // WhatsApp SVG icon — inline so no external asset needed
 function WhatsAppIcon() {
@@ -49,7 +49,6 @@ export function FooterSection() {
 						alt=""
 						width={30}
 						height={44}
-						unoptimized
 						aria-hidden="true"
 					/>
 				</div>

--- a/src/app/(site)/(home)/_components/footer-section/index.tsx
+++ b/src/app/(site)/(home)/_components/footer-section/index.tsx
@@ -18,11 +18,9 @@ function WhatsAppIcon() {
 
 export function FooterSection() {
 	return (
-		<footer className="w-full pb-10">
-			{/* Separator */}
-			<div className="mx-auto max-w-5xl px-6 md:px-[1.125rem]">
-				<hr className="border-border" />
-			</div>
+		<footer className="w-full pb-28">
+			{/* Separator — full-width edge to edge */}
+			<hr className="border-border" />
 
 			{/* Content */}
 			<div className="mx-auto mt-10 flex max-w-5xl flex-col items-center gap-6 px-6 md:px-[1.125rem]">

--- a/src/app/(site)/(home)/_components/intro-section/about-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/about-section.tsx
@@ -44,7 +44,7 @@ export function AboutSection({ bio }: AboutSectionProps) {
 			className={ARTICLE_PROSE}
 			initial={{ y: 48, opacity: 0 }}
 			whileInView={{ y: 0, opacity: 1 }}
-			viewport={{ once: true, margin: "0px 0px 0px 0px" }}
+			viewport={{ once: true }}
 			transition={{ ease: "easeInOut", duration: 0.7 }}
 		>
 			<PortableText

--- a/src/app/(site)/(home)/_components/intro-section/about-section.tsx
+++ b/src/app/(site)/(home)/_components/intro-section/about-section.tsx
@@ -44,7 +44,7 @@ export function AboutSection({ bio }: AboutSectionProps) {
 			className={ARTICLE_PROSE}
 			initial={{ y: 48, opacity: 0 }}
 			whileInView={{ y: 0, opacity: 1 }}
-			viewport={{ once: true, margin: "0px 0px -60px 0px" }}
+			viewport={{ once: true, margin: "0px 0px 0px 0px" }}
 			transition={{ ease: "easeInOut", duration: 0.7 }}
 		>
 			<PortableText

--- a/src/app/(site)/_components/site-page.tsx
+++ b/src/app/(site)/_components/site-page.tsx
@@ -43,7 +43,7 @@ const SECTION_CONFIGS: Partial<Record<HomeSectionKey, SectionConfig>> = {
 	work: {
 		id: "work",
 		className:
-			"mx-auto flex w-full max-w-5xl flex-col gap-16 px-6 pt-8 pb-24 md:px-11",
+			"mx-auto flex w-full max-w-5xl flex-col gap-16 px-6 pt-8 md:px-11",
 		Component: WorkSection,
 	},
 	blogs: {
@@ -65,7 +65,7 @@ export async function SitePage({
 		<main className="flex flex-col">
 			<section
 				id="about"
-				className="mx-auto flex w-full max-w-5xl flex-col pt-10 pb-20 md:pt-20 xl:pt-[7.5rem]"
+				className="mx-auto flex w-full max-w-5xl flex-col pt-10 md:pt-20 xl:pt-[7.5rem]"
 			>
 				<div className="flex flex-col-reverse gap-16 px-6 md:px-[1.125rem] xl:grid xl:grid-cols-2 xl:items-start xl:gap-16">
 					<IntroSection />
@@ -73,7 +73,7 @@ export async function SitePage({
 				</div>
 			</section>
 
-			<div className="flex flex-col gap-32 pb-[1.125rem] md:gap-40">
+			<div className="flex flex-col gap-22 mt-22 pb-6">
 				{sections
 					.filter((key) => key !== "intro")
 					.map((key) => {

--- a/src/app/(site)/_components/site-page.tsx
+++ b/src/app/(site)/_components/site-page.tsx
@@ -73,7 +73,7 @@ export async function SitePage({
 				</div>
 			</section>
 
-			<div className="flex flex-col gap-32 pb-20 md:gap-40">
+			<div className="flex flex-col gap-32 pb-[1.125rem] md:gap-40">
 				{sections
 					.filter((key) => key !== "intro")
 					.map((key) => {

--- a/src/app/(site)/_components/site-page.tsx
+++ b/src/app/(site)/_components/site-page.tsx
@@ -2,6 +2,7 @@ import { ScrollSpy } from "@/components/scroll-spy";
 import { getHomePageSections } from "@/sanity/lib/dal";
 import type { HomeSectionKey } from "@/sanity/lib/home-sections";
 import { ExperienceSection } from "../(home)/_components/experience-section";
+import { FooterSection } from "../(home)/_components/footer-section";
 import { IntroSection } from "../(home)/_components/intro-section";
 import { OtherWorksSection } from "../(home)/_components/other-works-section";
 import { TestimonialsSection } from "../(home)/_components/testimonials-section";
@@ -86,6 +87,9 @@ export async function SitePage({
 						);
 					})}
 			</div>
+
+			{/* Always-visible footer — intentionally outside the sections container */}
+			<FooterSection />
 
 			<ScrollSpy initialSection={initialSection} />
 		</main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,8 +32,6 @@
 	--radius-2xl: calc(var(--radius) + 8px);
 	--radius-3xl: calc(var(--radius) + 12px);
 	--radius-4xl: calc(var(--radius) + 16px);
-	--animate-shimmer-slide: shimmer-slide 3s ease-in-out infinite alternate;
-	--animate-spin-around: spin-around 6s infinite linear;
 }
 
 :root {
@@ -78,30 +76,6 @@
 	--secondary-foreground: #212121;
 	--accent: #f5f4f0;
 	--accent-foreground: #212121;
-}
-
-/* Shimmer button animations */
-@keyframes shimmer-slide {
-	to {
-		transform: translate(calc(100cqw - 100%), 0);
-	}
-}
-
-@keyframes spin-around {
-	0% {
-		transform: translateZ(0) rotate(0deg);
-	}
-	15%,
-	35% {
-		transform: translateZ(0) rotate(90deg);
-	}
-	65%,
-	85% {
-		transform: translateZ(0) rotate(270deg);
-	}
-	100% {
-		transform: translateZ(0) rotate(360deg);
-	}
 }
 
 @layer base {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,6 +32,8 @@
 	--radius-2xl: calc(var(--radius) + 8px);
 	--radius-3xl: calc(var(--radius) + 12px);
 	--radius-4xl: calc(var(--radius) + 16px);
+	--animate-shimmer-slide: shimmer-slide 3s ease-in-out infinite alternate;
+	--animate-spin-around: spin-around 6s infinite linear;
 }
 
 :root {
@@ -76,6 +78,30 @@
 	--secondary-foreground: #212121;
 	--accent: #f5f4f0;
 	--accent-foreground: #212121;
+}
+
+/* Shimmer button animations */
+@keyframes shimmer-slide {
+	to {
+		transform: translate(calc(100cqw - 100%), 0);
+	}
+}
+
+@keyframes spin-around {
+	0% {
+		transform: translateZ(0) rotate(0deg);
+	}
+	15%,
+	35% {
+		transform: translateZ(0) rotate(90deg);
+	}
+	65%,
+	85% {
+		transform: translateZ(0) rotate(270deg);
+	}
+	100% {
+		transform: translateZ(0) rotate(360deg);
+	}
 }
 
 @layer base {

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -30,8 +30,7 @@ export function Navbar() {
 			if (!divider || !navRef.current) return;
 
 			const hrTop = divider.getBoundingClientRect().top;
-			const navHeight = navRef.current.offsetHeight;
-			const computed = window.innerHeight - navHeight - hrTop + GAP;
+			const computed = window.innerHeight - hrTop + GAP;
 
 			navRef.current.style.bottom = `${Math.max(NORMAL_BOTTOM, computed)}px`;
 		};

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FOOTER_DIVIDER_ID } from "@/app/(site)/(home)/_components/footer-section";
 import { PATHNAME_TO_SECTION, type SectionId } from "@/lib/sections";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
@@ -20,19 +21,25 @@ export function Navbar() {
 	);
 
 	// Push the navbar up so it never crosses the footer divider.
-	// Maintains a 0.75rem (12px) gap between the divider and the navbar top.
+	// Maintains a 0.75rem (12px) gap between the navbar bottom edge and the divider.
+	// NORMAL_BOTTOM must stay in sync with style={{ bottom: "1.5rem" }} on the <nav>.
 	useEffect(() => {
-		const NORMAL_BOTTOM = 24; // 1.5rem in px (bottom-6)
+		const NORMAL_BOTTOM = 24; // 1.5rem in px — must match the inline style below
 		const GAP = 12; // 0.75rem in px
 
+		let rafId: number;
+
 		const updateBottom = () => {
-			const divider = document.getElementById("footer-divider");
-			if (!divider || !navRef.current) return;
+			cancelAnimationFrame(rafId);
+			rafId = requestAnimationFrame(() => {
+				const divider = document.getElementById(FOOTER_DIVIDER_ID);
+				if (!divider || !navRef.current) return;
 
-			const hrTop = divider.getBoundingClientRect().top;
-			const computed = window.innerHeight - hrTop + GAP;
+				const hrTop = divider.getBoundingClientRect().top;
+				const computed = window.innerHeight - hrTop + GAP;
 
-			navRef.current.style.bottom = `${Math.max(NORMAL_BOTTOM, computed)}px`;
+				navRef.current.style.bottom = `${Math.max(NORMAL_BOTTOM, computed)}px`;
+			});
 		};
 
 		window.addEventListener("scroll", updateBottom, { passive: true });
@@ -40,6 +47,7 @@ export function Navbar() {
 		updateBottom();
 
 		return () => {
+			cancelAnimationFrame(rafId);
 			window.removeEventListener("scroll", updateBottom);
 			window.removeEventListener("resize", updateBottom);
 		};

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -4,7 +4,7 @@ import { PATHNAME_TO_SECTION, type SectionId } from "@/lib/sections";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 const NAV_ITEMS = [
 	{ label: "About", href: "/", section: "about" },
@@ -14,9 +14,38 @@ const NAV_ITEMS = [
 
 export function Navbar() {
 	const pathname = usePathname();
+	const navRef = useRef<HTMLElement>(null);
 	const [activeSection, setActiveSection] = useState(
 		PATHNAME_TO_SECTION[pathname] ?? "about",
 	);
+
+	// Push the navbar up so it never crosses the footer divider.
+	// Maintains a 0.75rem (12px) gap between the divider and the navbar top.
+	useEffect(() => {
+		const NORMAL_BOTTOM = 24; // 1.5rem in px (bottom-6)
+		const GAP = 12; // 0.75rem in px
+
+		const updateBottom = () => {
+			const divider = document.getElementById("footer-divider");
+			if (!divider || !navRef.current) return;
+
+			const hrTop = divider.getBoundingClientRect().top;
+			const navHeight = navRef.current.offsetHeight;
+			const computed = window.innerHeight - navHeight - hrTop - GAP;
+
+			navRef.current.style.bottom = `${Math.max(NORMAL_BOTTOM, computed)}px`;
+		};
+
+		window.addEventListener("scroll", updateBottom, { passive: true });
+		window.addEventListener("resize", updateBottom, { passive: true });
+		updateBottom();
+
+		return () => {
+			window.removeEventListener("scroll", updateBottom);
+			window.removeEventListener("resize", updateBottom);
+		};
+	}, []);
+
 	useEffect(() => {
 		const handler = (e: Event) => {
 			const { section } = (e as CustomEvent<{ section: SectionId }>).detail;
@@ -59,8 +88,10 @@ export function Navbar() {
 
 	return (
 		<nav
+			ref={navRef}
 			data-slot="navbar"
-			className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2"
+			className="fixed left-1/2 z-50 -translate-x-1/2"
+			style={{ bottom: "1.5rem" }}
 			aria-label="Main navigation"
 		>
 			<div className="flex items-center rounded-full border border-border bg-background px-[0.875rem] py-2 shadow-[0_4px_12px_rgba(0,0,0,0.5)]">

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { FOOTER_DIVIDER_ID } from "@/app/(site)/(home)/_components/footer-section";
-import { PATHNAME_TO_SECTION, type SectionId } from "@/lib/sections";
+import { FOOTER_DIVIDER_ID, PATHNAME_TO_SECTION, type SectionId } from "@/lib/sections";
 import { cn } from "@/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -31,7 +31,7 @@ export function Navbar() {
 
 			const hrTop = divider.getBoundingClientRect().top;
 			const navHeight = navRef.current.offsetHeight;
-			const computed = window.innerHeight - navHeight - hrTop - GAP;
+			const computed = window.innerHeight - navHeight - hrTop + GAP;
 
 			navRef.current.style.bottom = `${Math.max(NORMAL_BOTTOM, computed)}px`;
 		};

--- a/src/lib/sections.ts
+++ b/src/lib/sections.ts
@@ -2,6 +2,8 @@ export const SECTIONS = ["about", "work", "blogs"] as const;
 
 export type SectionId = (typeof SECTIONS)[number];
 
+export const FOOTER_DIVIDER_ID = "footer-divider";
+
 export const SECTION_URLS: Record<SectionId, string> = {
 	about: "/",
 	work: "/work",


### PR DESCRIPTION
## Summary

- Add **"Let's Work Together :)"** footer section matching Figma design (`1456:398`)
  - Caveat serif heading with a yellow → coral gradient on "together"
  - Flower.png decoration aligned to the heading's top
  - Full-width `<hr>` divider (edge to edge, not constrained by `max-w-5xl`)
  - WhatsApp CTA button (`wa.me/918008892112`) with green background and inline SVG icon
- **Navbar scroll-stop**: fixed bottom navbar dynamically lifts above the footer divider using a `requestAnimationFrame`-throttled scroll/resize listener — navbar bottom edge stays 12 px above the `<hr>` as the user scrolls into the footer
- **Mobile bio animation fix**: removed the `-60 px` `whileInView` viewport margin that caused the bio text to stay invisible on first load on short screens
- **Section spacing cleanup**: replaced ad-hoc `pb-20`/`pb-24` per section with a uniform `gap-22` + `mt-22` container; sections container uses `pb-6`

## Changes

| File | What changed |
|---|---|
| `src/lib/sections.ts` | Added `FOOTER_DIVIDER_ID` constant (shared location, avoids page→shared import inversion) |
| `footer-section/index.tsx` | Imports + re-exports `FOOTER_DIVIDER_ID` from `@/lib/sections`; removed `unoptimized` from `/Flower.png` (next/image already optimises local assets) |
| `src/components/navbar.tsx` | Now imports `FOOTER_DIVIDER_ID` from `@/lib/sections` instead of the page-scoped footer component; RAF-throttled scroll listener lifts navbar above divider |
| `intro-section/about-section.tsx` | Removed `margin: "0px 0px -60px 0px"` — fixes bio invisible on first load on short screens |
| `src/app/(site)/_components/site-page.tsx` | Adds `<FooterSection />` outside the sections container so it always renders; removes per-section bottom padding |

## Review fixes applied

| Finding | Fix |
|---|---|
| `FOOTER_DIVIDER_ID` lived in a page-scoped component but was imported by the shared `Navbar` | Moved to `src/lib/sections.ts`; footer re-exports for backwards compat |
| `unoptimized` on `/Flower.png` disabled Next.js image optimisation with no benefit | Removed |
| No RAF throttling on scroll listener | `requestAnimationFrame` / `cancelAnimationFrame` pattern; `NORMAL_BOTTOM` sync documented in comment |
| Dead shimmer CSS in `globals.css` | Removed `--animate-shimmer-slide`, `--animate-spin-around` tokens and `@keyframes` |
| Redundant `margin: "0px 0px 0px 0px"` in `AboutSection` | Removed |

## Test plan

- [ ] Footer heading renders with gradient on "together" and Flower decoration
- [ ] WhatsApp button opens `wa.me/918008892112` in a new tab
- [ ] `<hr>` divider spans full viewport width
- [ ] On desktop: scroll to footer — navbar lifts and never overlaps the divider
- [ ] On mobile: bio text is visible on first page load without any scroll
- [ ] Section gaps are consistent between About → OtherWorks → Work → Testimonials
- [ ] `bun run lint:check` passes with 0 errors
- [ ] `bun run typecheck` passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)